### PR TITLE
Move ID subscription and history loading code into `loadDeviceFilter()`

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -14,6 +14,8 @@ const EPSG_3857 = 'EPSG:3857';
 export default Controller.extend({
   filter: service(),
   scoring: service(),
+  history: service(),
+  ws: service(),
   mapService: service('map'),
 
   hasDeviceFilter: alias('filter.hasFilter'),
@@ -30,6 +32,14 @@ export default Controller.extend({
   async loadDeviceFilter(url) {
     if (url) {
       await this.filter.load(url);
+
+      if (this.filter.hasFilter) {
+        for (let row of this.filter.filter) {
+          this.ws.subscribeToId(row.ID);
+        }
+
+        this.history.loadForIds(...this.filter.filter.map(row => row.ID));
+      }
     }
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,12 +18,5 @@ export default Route.extend({
     this.ddb.update();
 
     this.ws.start();
-    if (this.filter.hasFilter) {
-      for (let row of this.filter.filter) {
-        this.ws.subscribeToId(row.ID);
-      }
-
-      this.history.loadForIds(...this.filter.filter.map(row => row.ID));
-    }
   },
 });


### PR DESCRIPTION
This was previously broken because `hasFilter` was not yet set at that point in time