### PR TITLE
Use `ember-cli-dependency-lint` to warn about duplicate addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ install:
 script:
   - yarn lint:hbs
   - yarn lint:js
+  - yarn ember dependency-lint
   - yarn test

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-cli": "~3.9.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-dependency-checker": "^3.0.0",
+    "ember-cli-dependency-lint": "^1.1.3",
     "ember-cli-favicon": "^2.0.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,6 +1680,11 @@ aprs-parser@^1.0.4:
   resolved "https://registry.yarnpkg.com/aprs-parser/-/aprs-parser-1.0.4.tgz#d09b288f9d5fd207f7be14fa3e9e99c07fc6a64a"
   integrity sha1-0Jsoj51f0gf3vhT6Pp6ZwH/Gpko=
 
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -4572,6 +4577,16 @@ ember-cli-dependency-checker@^3.0.0:
     is-git-url "^1.0.0"
     resolve "^1.5.0"
     semver "^5.3.0"
+
+ember-cli-dependency-lint@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-dependency-lint/-/ember-cli-dependency-lint-1.1.3.tgz#ece5a319734d0b0462c12fd7a93d322e1f9fe60f"
+  integrity sha512-v836nMZuYhnvZ7MvIwGkwJkFhx7gc7RrlNcD90IHdBpR7kWBXIljLgSNIae84qKn1V1UqHImBTMnJvJCe2qvQw==
+  dependencies:
+    archy "^1.0.0"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.3.0"
+    semver "^5.5.0"
 
 ember-cli-favicon@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
see https://github.com/salsify/ember-cli-dependency-lint/