### PR TITLE
Improve device ID parsing

### DIFF
--- a/app/services/filter.js
+++ b/app/services/filter.js
@@ -18,7 +18,7 @@ export default Service.extend({
       'filter',
       data.map(row => ({
         ...row,
-        ID: normalizeDeviceId(row.ID),
+        ID: normalizeDeviceId(row.ID) || row.ID,
         HANDICAP: 'HANDICAP' in row ? parseFloat(row.HANDICAP) : 1.0,
       })),
     );

--- a/app/services/filter.js
+++ b/app/services/filter.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { notEmpty } from '@ember/object/computed';
 import fetchText from 'ogn-web-viewer/utils/fetch-text';
+import { normalizeDeviceId } from 'ogn-web-viewer/utils/normalize-device-id';
 
 export default Service.extend({
   init() {
@@ -17,7 +18,7 @@ export default Service.extend({
       'filter',
       data.map(row => ({
         ...row,
-        ID: parseID(row.ID),
+        ID: normalizeDeviceId(row.ID),
         HANDICAP: 'HANDICAP' in row ? parseFloat(row.HANDICAP) : 1.0,
       })),
     );
@@ -29,16 +30,4 @@ export default Service.extend({
 async function loadNeatCSV() {
   let neatCSV = await import('neat-csv');
   return neatCSV.default;
-}
-
-export function parseID(id) {
-  if (id.startsWith('06') && id.length === 8) {
-    return `FLR${id.substr(2)}`;
-  }
-
-  if (id.length === 6) {
-    return `FLR${id}`;
-  }
-
-  return id;
 }

--- a/app/utils/normalize-device-id.js
+++ b/app/utils/normalize-device-id.js
@@ -15,7 +15,7 @@ export function normalizeDeviceId(id) {
     return null;
   }
 
-  if (id.length === 6) {
+  if (id.length === 6 && !isNaN(parseInt(id, 16))) {
     return `FLR${id}`;
   }
 

--- a/app/utils/normalize-device-id.js
+++ b/app/utils/normalize-device-id.js
@@ -1,6 +1,18 @@
 export function normalizeDeviceId(id) {
-  if (id.startsWith('06') && id.length === 8) {
-    return `FLR${id.substr(2)}`;
+  if (id.length === 8) {
+    let senderDetails = parseInt(id.substring(0, 2), 16);
+    if (!isNaN(senderDetails)) {
+      let addressType = senderDetails & 0b00000011;
+      if (addressType === 0b01) {
+        return `ICA${id.substring(2)}`;
+      } else if (addressType === 0b10) {
+        return `FLR${id.substring(2)}`;
+      } else if (addressType === 0b11) {
+        return `OGN${id.substring(2)}`;
+      }
+    }
+
+    return null;
   }
 
   if (id.length === 6) {

--- a/app/utils/normalize-device-id.js
+++ b/app/utils/normalize-device-id.js
@@ -1,0 +1,11 @@
+export function normalizeDeviceId(id) {
+  if (id.startsWith('06') && id.length === 8) {
+    return `FLR${id.substr(2)}`;
+  }
+
+  if (id.length === 6) {
+    return `FLR${id}`;
+  }
+
+  return id;
+}

--- a/app/utils/normalize-device-id.js
+++ b/app/utils/normalize-device-id.js
@@ -1,7 +1,15 @@
+const RE_HEXDEC = /^[0-9a-fA-F]+$/;
+
 export function normalizeDeviceId(id) {
-  if (id.length === 8) {
-    let senderDetails = parseInt(id.substring(0, 2), 16);
-    if (!isNaN(senderDetails)) {
+  let length = id.length;
+
+  if (length === 6) {
+    if (RE_HEXDEC.test(id)) {
+      return `FLR${id}`;
+    }
+  } else if (length === 8) {
+    if (RE_HEXDEC.test(id)) {
+      let senderDetails = parseInt(id.substring(0, 2), 16);
       let addressType = senderDetails & 0b00000011;
       if (addressType === 0b01) {
         return `ICA${id.substring(2)}`;
@@ -11,16 +19,10 @@ export function normalizeDeviceId(id) {
         return `OGN${id.substring(2)}`;
       }
     }
-
-    return null;
-  }
-
-  if (id.length === 6 && !isNaN(parseInt(id, 16))) {
-    return `FLR${id}`;
-  }
-
-  if (id.length === 9 && !isNaN(parseInt(id.substring(3), 16))) {
-    return id;
+  } else if (length === 9) {
+    if (RE_HEXDEC.test(id.substring(3))) {
+      return id;
+    }
   }
 
   return null;

--- a/app/utils/normalize-device-id.js
+++ b/app/utils/normalize-device-id.js
@@ -19,5 +19,9 @@ export function normalizeDeviceId(id) {
     return `FLR${id}`;
   }
 
-  return id;
+  if (id.length === 9 && !isNaN(parseInt(id.substring(3), 16))) {
+    return id;
+  }
+
+  return null;
 }

--- a/tests/normalize-device-id-test.js
+++ b/tests/normalize-device-id-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { normalizeDeviceId } from 'ogn-web-viewer/utils/normalize-device-id';
+
+module('normalizeDeviceId()', function() {
+  const TESTS = [
+    ['FLRDDA5BA', 'FLRDDA5BA'],
+    ['ICA4B0E3A', 'ICA4B0E3A'],
+    ['OGNE95A16', 'OGNE95A16'],
+    ['06DDA524', 'FLRDDA524'],
+    ['DDA524', 'FLRDDA524'],
+  ];
+
+  for (let [input, expected] of TESTS) {
+    test(`${input} -> ${expected}`, function(assert) {
+      let output = normalizeDeviceId(input);
+      assert.equal(output, expected);
+    });
+  }
+});

--- a/tests/normalize-device-id-test.js
+++ b/tests/normalize-device-id-test.js
@@ -12,6 +12,9 @@ module('normalizeDeviceId()', function() {
     ['053E5E5C', 'ICA3E5E5C'],
     ['22D00442', 'FLRD00442'],
     ['3AA007', 'FLR3AA007'],
+    ['XXXXXX', null],
+    ['FLRXXXXXX', null],
+    ['1234567890', null],
   ];
 
   for (let [input, expected] of TESTS) {

--- a/tests/normalize-device-id-test.js
+++ b/tests/normalize-device-id-test.js
@@ -8,6 +8,10 @@ module('normalizeDeviceId()', function() {
     ['OGNE95A16', 'OGNE95A16'],
     ['06DDA524', 'FLRDDA524'],
     ['DDA524', 'FLRDDA524'],
+    ['XX123456', null],
+    ['053E5E5C', 'ICA3E5E5C'],
+    ['22D00442', 'FLRD00442'],
+    ['3AA007', 'FLR3AA007'],
   ];
 
   for (let [input, expected] of TESTS) {


### PR DESCRIPTION
This PR improves the code that turns device IDs like `06DDA524` from the CSV filter file into APRS sender IDs like `FLRDDA524`. Previously it was hacked together and hardcoded to detect the `06` prefix, now it tries to properly parse the device ID and also supports OGN and ICAO addresses.