### PR TITLE
dependency-lint: Disable test generation

### DIFF
--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  generateTests: false,
+};


### PR DESCRIPTION
We already run the dependency-lint in the CI suite, so we don't need to generate any tests