### PR TITLE
package.json: Move imported dependencies into `dependencies` section

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,18 @@
     "start:replay": "REPLAY=true ember serve",
     "test": "ember test"
   },
+  "dependencies": {
+    "aeroscore": "^0.2.1",
+    "igc-parser": "^0.4.0",
+    "lolex": "^4.0.1",
+    "mock-socket": "^8.0.5",
+    "neat-csv": "^4.0.0",
+    "ol": "^5.3.2",
+    "sockette": "^2.0.5"
+  },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
     "@pollyjs/ember": "^2.3.1",
-    "aeroscore": "^0.2.1",
     "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.3.0",
@@ -52,15 +60,9 @@
     "eslint-plugin-ember": "^6.4.1",
     "eslint-plugin-prettier": "^3.0.1",
     "git-repo-info": "^2.1.0",
-    "igc-parser": "^0.4.0",
     "loader.js": "^4.7.0",
-    "lolex": "^4.0.1",
-    "mock-socket": "^8.0.5",
-    "neat-csv": "^4.0.0",
-    "ol": "^5.3.2",
     "prettier": "1.17.0",
-    "qunit-dom": "^0.8.0",
-    "sockette": "^2.0.5"
+    "qunit-dom": "^0.8.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
This makes it a little more obvious which dependencies are being imported by the app, and which are only build-time dependencies.