### PR TITLE
igc-replay: Disable replay if `Ember.testing` is detected

### DIFF
--- a/lib/igc-replay/addon/instance-initializers/igc-replay.js
+++ b/lib/igc-replay/addon/instance-initializers/igc-replay.js
@@ -1,5 +1,9 @@
+import Ember from 'ember';
+
 export function initialize(appInstance) {
-  appInstance.lookup('service:igc-replay').start();
+  if (!Ember.testing) {
+    appInstance.lookup('service:igc-replay').start();
+  }
 }
 
 export default { initialize };


### PR DESCRIPTION
This makes it possible to use the `/tests` route even if the `ember serve` command was started in replay mode.