### PR TITLE
Enable IGC replay using `replay` query parameter instead of env var

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,7 @@ module.exports = function(defaults) {
   let repoInfo = getRepoInfo();
 
   let pluginsToBlacklist = [];
-  if (!process.env.REPLAY) {
+  if (isProductionEnv) {
     pluginsToBlacklist.push('igc-replay');
   }
 

--- a/lib/igc-replay/addon/instance-initializers/igc-replay.js
+++ b/lib/igc-replay/addon/instance-initializers/igc-replay.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import window from 'ember-window-mock';
 
 export function initialize(appInstance) {
-  if (!Ember.testing) {
+  let params = new URLSearchParams(window.location.search);
+  if (params.has('replay')) {
     appInstance.lookup('service:igc-replay').start();
   }
 }


### PR DESCRIPTION
The `replay` parameter will only be available in development builds and the code should be entirely stripped out for the production build.