### PR TITLE
Use IGC Replay service/addon for tests

### DIFF
--- a/app/utils/timeout.js
+++ b/app/utils/timeout.js
@@ -1,0 +1,8 @@
+/**
+ * Alternative to the `timeout()` function from `ember-concurrency` that
+ * does not use the Ember runloop. By not using the Ember runloop it causes
+ * it to not block any async tests.
+ */
+export default async function timeout(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}

--- a/lib/igc-replay/addon-test-support/index.js
+++ b/lib/igc-replay/addon-test-support/index.js
@@ -1,0 +1,12 @@
+export function setupReplay(hooks, options = {}) {
+  hooks.beforeEach(function() {
+    this.replay = this.owner.lookup('service:igc-replay');
+    this.replay.start(options);
+  });
+
+  hooks.afterEach(function() {
+    if (this.replay) {
+      this.replay.stop();
+    }
+  });
+}

--- a/lib/igc-replay/addon/services/igc-replay.js
+++ b/lib/igc-replay/addon/services/igc-replay.js
@@ -14,8 +14,10 @@ import fetchText from 'ogn-web-viewer/utils/fetch-text';
 const START_TIME = Date.parse('2018-05-27T12:32:28Z');
 
 export default Service.extend({
-  start() {
-    this.clock = lolex.install({ now: START_TIME, shouldAdvanceTime: true });
+  start(options = {}) {
+    let now = 'now' in options ? options.now : START_TIME;
+
+    this.clock = lolex.install({ now, shouldAdvanceTime: true });
 
     this.polly = new Polly('igc-replay', { recordIfMissing: false, logging: true });
     this.polly.server.get('https://maps.tilehosting.com/*').passthrough();

--- a/lib/igc-replay/addon/services/igc-replay.js
+++ b/lib/igc-replay/addon/services/igc-replay.js
@@ -20,7 +20,7 @@ export default Service.extend({
 
     this.clock = lolex.install({ now, shouldAdvanceTime: true });
 
-    this.polly = new Polly('igc-replay', { recordIfMissing: false, logging: true });
+    this.polly = new Polly('igc-replay', { recordIfMissing: false });
     this.polly.server.get('https://maps.tilehosting.com/*').passthrough();
     this.polly.server.get('/igc-replay/*').passthrough();
 

--- a/lib/igc-replay/addon/services/igc-replay.js
+++ b/lib/igc-replay/addon/services/igc-replay.js
@@ -24,6 +24,8 @@ export default Service.extend({
     this.polly.server.get('https://maps.tilehosting.com/*').passthrough();
     this.polly.server.get('/igc-replay/*').passthrough();
 
+    this.polly.server.get(`${config.API_HOST}/api/ddb`).intercept((req, res) => res.status(200).send({}));
+
     this.polly.server.get(`${config.API_HOST}/api/records/:ids`).intercept(async (req, res) => {
       await waitForProperty(
         this,

--- a/lib/igc-replay/addon/services/igc-replay.js
+++ b/lib/igc-replay/addon/services/igc-replay.js
@@ -85,7 +85,8 @@ export default Service.extend({
     this.files.set(ognID, parsed);
     this.set('filesLoaded', this.filesLoaded + 1);
 
-    let nextIndex = parsed.fixes.findIndex(it => it.timestamp > START_TIME);
+    let now = Date.now();
+    let nextIndex = parsed.fixes.findIndex(it => it.timestamp > now);
     let prevPoint = null;
 
     while (true) {

--- a/lib/igc-replay/addon/services/igc-replay.js
+++ b/lib/igc-replay/addon/services/igc-replay.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { task, all, timeout, waitForProperty } from 'ember-concurrency';
+import { task, all, waitForProperty } from 'ember-concurrency';
 import ajax from 'ember-fetch/ajax';
 import { Server } from 'mock-socket';
 import lolex from 'lolex';
@@ -10,6 +10,7 @@ import bearing from '@turf/bearing';
 
 import config from 'ogn-web-viewer/config/environment';
 import fetchText from 'ogn-web-viewer/utils/fetch-text';
+import timeout from 'ogn-web-viewer/utils/timeout';
 
 const START_TIME = Date.parse('2018-05-27T12:32:28Z');
 

--- a/tests/application/filter-loading-test.js
+++ b/tests/application/filter-loading-test.js
@@ -1,22 +1,18 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
-import { setupQunit as setupPolly } from '@pollyjs/core';
 import window, { setupWindowMock } from 'ember-window-mock';
+import { setupReplay } from 'igc-replay/test-support';
 
 const URL = 'https://gist.githubusercontent.com/Turbo87/1234567890/raw/club-filter.csv';
 
 module('Application | filter-loading', function(hooks) {
   setupApplicationTest(hooks);
-  setupPolly(hooks, { recordIfMissing: false });
   setupWindowMock(hooks);
+  setupReplay(hooks);
 
   test('visiting / loads the filter file when available', async function(assert) {
-    const { server } = this.polly;
-
-    server.get('https://maps.tilehosting.com/*').passthrough();
-    server.get('/api/ddb').intercept((req, res) => res.status(200).send({}));
-    server.get('/api/records/:ids').intercept((req, res) => res.status(200).send({}));
+    const { server } = this.replay.polly;
 
     server.get(URL).intercept((req, res) => {
       let file = [


### PR DESCRIPTION
This PR reuses the IGC Replay functionality introduced in #16 to mock requests in application tests to make the tests easier to write.