### PR TITLE
Convert the GliderTracker-style hash params to query params

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,10 @@
 import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
+import { hashToQueryParams } from 'ogn-web-viewer/utils/hash-to-qp';
 import config from './config/environment';
+
+hashToQueryParams();
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { run } from '@ember/runloop';
-import window from 'ember-window-mock';
 
 import { scaleFromCenter } from 'ol/extent';
 import { transformExtent } from 'ol/proj';
@@ -19,11 +18,10 @@ export default class extends Route {
   @service ws;
   @service('map') mapService;
 
-  async model() {
-    let hash = window.location.hash || '';
-    let params = new URLSearchParams(hash.substr(1));
+  async model(params, transition) {
+    let { queryParams } = transition.to;
 
-    return Promise.all([this.loadDeviceFilter(params.get('lst')), this.loadTask(params.get('tsk'))]);
+    return Promise.all([this.loadDeviceFilter(queryParams.lst), this.loadTask(queryParams.tsk)]);
   }
 
   setupController(controller, [filter, task]) {

--- a/app/utils/hash-to-qp.js
+++ b/app/utils/hash-to-qp.js
@@ -1,0 +1,38 @@
+import window from 'ember-window-mock';
+
+/**
+ * Converts the GliderTracker-style hash params (`lst` and `tsk`) to
+ * query parameters.
+ */
+export function hashToQueryParams() {
+  let { hash, search } = window.location;
+  if (hash[0] !== '#') return;
+
+  let hashParams = new URLSearchParams(hash.substring(1));
+  let searchParams = new URLSearchParams(search);
+
+  if (hashParams.has('lst')) {
+    let lst = hashParams.get('lst');
+    searchParams.set('lst', lst);
+    hashParams.delete('lst');
+  }
+
+  if (hashParams.has('tsk')) {
+    let tsk = hashParams.get('tsk');
+    searchParams.set('tsk', tsk);
+    hashParams.delete('tsk');
+  }
+
+  let newHash = hashParams.toString();
+  if (newHash) {
+    newHash = `#${newHash}`;
+  }
+
+  let newSearch = searchParams.toString();
+  if (newSearch) {
+    newSearch = `?${newSearch}`;
+  }
+
+  window.location.search = newSearch;
+  window.location.hash = newHash;
+}

--- a/tests/application/filter-loading-test.js
+++ b/tests/application/filter-loading-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 import { setupReplay } from 'igc-replay/test-support';
 
 const URL = 'https://gist.githubusercontent.com/Turbo87/1234567890/raw/club-filter.csv';
 
 module('Application | filter-loading', function(hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupReplay(hooks);
 
   test('visiting / loads the filter file when available', async function(assert) {
@@ -25,8 +23,7 @@ module('Application | filter-loading', function(hooks) {
       return res.status(200).send(file);
     });
 
-    window.location.hash = `#lst=${URL}`;
-    await visit('/');
+    await visit(`/?lst=${URL}`);
 
     let filter = this.owner.lookup('service:filter');
 

--- a/tests/utils/hash-to-qp-test.js
+++ b/tests/utils/hash-to-qp-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import window, { setupWindowMock } from 'ember-window-mock';
+
+import { hashToQueryParams } from 'ogn-web-viewer/utils/hash-to-qp';
+
+module('Utils | hashToQueryParams', function(hooks) {
+  setupWindowMock(hooks);
+
+  hooks.beforeEach(function() {
+    window.location.hash = '';
+    window.location.search = '';
+  });
+
+  test('empty hash -> empty QP', function(assert) {
+    hashToQueryParams();
+    assert.equal(window.location.hash, '');
+    assert.equal(window.location.search, '');
+  });
+
+  test('lst hash -> lst QP', function(assert) {
+    window.location.hash = `#lst=foo.csv`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '');
+    assert.equal(window.location.search, '?lst=foo.csv');
+  });
+
+  test('tsk hash -> tsk QP', function(assert) {
+    window.location.hash = `#tsk=foo.tsk`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '');
+    assert.equal(window.location.search, '?tsk=foo.tsk');
+  });
+
+  test('foo hash -> foo hash', function(assert) {
+    window.location.hash = `#foo=bar`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '#foo=bar');
+    assert.equal(window.location.search, '');
+  });
+
+  test('multiple params', function(assert) {
+    window.location.hash = `#lst=foo.csv&tsk=bar.tsk`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '');
+    assert.equal(window.location.search, '?lst=foo.csv&tsk=bar.tsk');
+  });
+
+  test('multiple params with existing QP', function(assert) {
+    window.location.search = `?foo=bar&baz`;
+    window.location.hash = `#lst=foo.csv&tsk=bar.tsk&qux`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '#qux=');
+    assert.equal(window.location.search, '?foo=bar&baz=&lst=foo.csv&tsk=bar.tsk');
+  });
+
+  test('realistic', function(assert) {
+    window.location.search = ``;
+    window.location.hash = `#tsk=https://gist.githubusercontent.com/Turbo87/62167f4f16f3e94f7bd04d7d6388d79d/raw/club.tsk&lst=https://gist.githubusercontent.com/Turbo87/62167f4f16f3e94f7bd04d7d6388d79d/raw/club-filter.csv`;
+
+    hashToQueryParams();
+    assert.equal(window.location.hash, '');
+    assert.equal(
+      window.location.search,
+      '?lst=https%3A%2F%2Fgist.githubusercontent.com%2FTurbo87%2F62167f4f16f3e94f7bd04d7d6388d79d%2Fraw%2Fclub-filter.csv&tsk=https%3A%2F%2Fgist.githubusercontent.com%2FTurbo87%2F62167f4f16f3e94f7bd04d7d6388d79d%2Fraw%2Fclub.tsk',
+    );
+  });
+});


### PR DESCRIPTION
This has the advantage that changing the embedded URLs in the query params reloads the page with the new data, instead of doing nothing, like before.

As a nice side-effect, it also simplifies the `visit()` helper calls in our test suite :)