### PR TITLE
services/history: Fix broken URL building for device IDs with ? in them

### DIFF
--- a/app/services/history.js
+++ b/app/services/history.js
@@ -10,7 +10,8 @@ export default class extends Service {
   async loadForIds(...ids) {
     let after = Math.round(Date.now() / 1000) - 8 * 60 * 60;
 
-    let url = `${config.API_HOST}/api/records/${ids.join(',')}?after=${after}`;
+    let idList = encodeURIComponent(ids.join(','));
+    let url = `${config.API_HOST}/api/records/${idList}?after=${after}`;
     let data = await ajax(url);
 
     for (let id of ids) {


### PR DESCRIPTION
Using `FLR??????` inside the filter list caused the `?after=...` query param to not be used correctly. Encoding the Flarm IDs before adding them to the URL solves that issue.