### PR TITLE
Sentry: Add git SHA1 as release name

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = function(environment) {
+  let repoInfo = require('git-repo-info')();
+
   let ENV = {
     modulePrefix: 'ogn-web-viewer',
     environment,
@@ -23,6 +25,7 @@ module.exports = function(environment) {
 
     sentry: {
       environment,
+      release: repoInfo.sha,
     },
   };
 


### PR DESCRIPTION
to take advantage of https://docs.sentry.io/workflow/releases/