### PR TITLE
Remove obsolete `ember-decorators-polyfill` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "ember-concurrency": "^0.10.0",
     "ember-concurrency-decorators": "^1.0.0-beta.2",
     "ember-css-modules": "^1.2.0",
-    "ember-decorators-polyfill": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^6.5.1",
     "ember-freestyle": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,7 +5032,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.16.0,
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.4.3, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.4.3, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
@@ -5424,15 +5424,6 @@ ember-css-modules@^1.2.0:
     postcss "^6.0.19"
     semver "^5.5.0"
     toposort "^1.0.6"
-
-ember-decorators-polyfill@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.0.4.tgz#d563b02e4256ec4ad48c1534e9bedd6cc27898c5"
-  integrity sha512-GoCPwWX4x5Xqn6jwr2DaWS4bqjnpXlc4oGTXVWcn2Wh++ZE27yURr7ZRMEQROc8c4omndzlsrM83kTLSIq0XAA==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-    ember-cli-version-checker "^3.1.3"
-    ember-compatibility-helpers "^1.2.0"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
We are using Ember 3.10 now, so the polyfill is no longer needed.