### PR TITLE
Add `/strepla` routes

### DIFF
--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -9,7 +9,15 @@ export default class extends Controller {
 
   @computed('error')
   get fetchResponse() {
-    return 'statusText' in this.error ? this.error : null;
+    if (this.error.response) {
+      return this.error.response;
+    }
+
+    if ('statusText' in this.error) {
+      return this.error;
+    }
+
+    return null;
   }
 
   setError(error) {

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,14 @@ const Router = EmberRouter.extend({
 
 // eslint-disable-next-line array-callback-return
 Router.map(function() {
+  this.route('strepla', function() {
+    this.route('competition', { path: '/:id' }, function() {
+      this.route('class', { path: '/:class_name' }, function() {
+        this.route('date', { path: '/:date' }, function() {});
+      });
+    });
+  });
+
   this.route('404', { path: '/*path' });
 
   if (config.environment !== 'production') {

--- a/app/routes/strepla/competition.js
+++ b/app/routes/strepla/competition.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class extends Route {
+  async model({ id }) {
+    return await this.store.findRecord('strepla-competition', id);
+  }
+}

--- a/app/routes/strepla/competition/class.js
+++ b/app/routes/strepla/competition/class.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+
+export default class extends Route {
+  async model({ class_name: className }) {
+    let competition = this.modelFor('strepla.competition');
+
+    let classes = await this.store.query('strepla-competition-class', { competitionId: competition.id });
+    let classRecord = classes.find(it => it.name === className);
+    if (!classRecord) {
+      throw new Error(`Competition class ${className} could not be found`);
+    }
+
+    return classRecord;
+  }
+}

--- a/app/routes/strepla/competition/class/date.js
+++ b/app/routes/strepla/competition/class/date.js
@@ -1,0 +1,22 @@
+import Route from '@ember/routing/route';
+
+import { toDateString } from 'ogn-web-viewer/utils/date';
+
+export default class extends Route {
+  async model({ date }) {
+    let competition = this.modelFor('strepla.competition');
+    let classRecord = this.modelFor('strepla.competition.class');
+
+    let days = await this.store.query('strepla-competition-day', { competitionId: competition.id });
+    let day = days.find(it => it.belongsTo('class').id() === classRecord.id && toDateString(it.date) === date);
+    if (!day) {
+      throw new Error(`No competition day matching "${date}" found for the "${classRecord.name}" competition class`);
+    }
+
+    return day;
+  }
+
+  serialize(model) {
+    return { date: toDateString(model.date) };
+  }
+}

--- a/app/routes/strepla/competition/class/date/index.js
+++ b/app/routes/strepla/competition/class/date/index.js
@@ -1,0 +1,88 @@
+import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+
+import { scaleFromCenter } from 'ol/extent';
+import { transformExtent } from 'ol/proj';
+
+import { normalizeDeviceId } from 'ogn-web-viewer/utils/normalize-device-id';
+import { convertTask } from 'ogn-web-viewer/utils/strepla-to-xcsoar';
+
+const EPSG_4326 = 'EPSG:4326';
+const EPSG_3857 = 'EPSG:3857';
+
+export default class extends Route {
+  @service filter;
+  @service scoring;
+  @service history;
+  @service ws;
+  @service('map') mapService;
+
+  async model() {
+    let competition = this.modelFor('strepla.competition');
+    let competitionClass = this.modelFor('strepla.competition.class');
+    let competitionDay = this.modelFor('strepla.competition.class.date');
+
+    let [competitors, task] = await Promise.all([
+      this.loadCompetitors(competition.id, competitionClass.name),
+      this.loadTask(competition.id, competitionDay.id),
+    ]);
+
+    return { competitors, task };
+  }
+
+  async loadTask(competitionId, competitionDayId) {
+    let [taskRecord, { readTaskFromString }] = await Promise.all([
+      this.store.queryRecord('strepla-task', {
+        competitionId,
+        competitionDayId,
+      }),
+      import('aeroscore/dist/src/read-task'),
+    ]);
+
+    let xmlTask = convertTask(taskRecord);
+
+    return readTaskFromString(xmlTask);
+  }
+
+  async loadCompetitors(competitionId, className) {
+    let competitors = await this.store.query('strepla-competitor', {
+      competitionId,
+      className,
+    });
+
+    return competitors.map(it => {
+      let id = normalizeDeviceId(it.flarmID) || it.flarmID;
+      let name = it.name;
+      let registration = it.registration;
+      let callsign = it.callsign;
+      let type = it.type;
+      let handicap = it.handicap || 1;
+      return { id, name, registration, callsign, type, handicap };
+    });
+  }
+
+  setupController(controller, { competitors, task }) {
+    if (competitors.length !== 0) {
+      run(() => this.filter.add(...competitors));
+
+      for (let record of competitors) {
+        this.ws.subscribeToId(record.id);
+      }
+
+      this.history.loadForIds(...competitors.map(record => record.id));
+    }
+
+    run(() => this.scoring.set('task', task));
+    this.mapService.map.updateSize();
+
+    if (task) {
+      // zoom map in on the task area
+      let bbox = task.bbox.slice();
+      scaleFromCenter(bbox, 0.3);
+      let extent = transformExtent(bbox, EPSG_4326, EPSG_3857);
+
+      setTimeout(() => this.mapService.map.getView().fit(extent, { duration: 1000 }), 100);
+    }
+  }
+}

--- a/app/routes/strepla/competition/class/index.js
+++ b/app/routes/strepla/competition/class/index.js
@@ -1,0 +1,31 @@
+import Route from '@ember/routing/route';
+
+import { toDateString } from 'ogn-web-viewer/utils/date';
+
+export default class extends Route {
+  async beforeModel() {
+    let competition = this.modelFor('strepla.competition');
+    let classRecord = this.modelFor('strepla.competition.class');
+
+    let days = await this.store.query('strepla-competition-day', { competitionId: competition.id });
+    let classDays = days.filter(it => it.belongsTo('class').id() === classRecord.id);
+    if (classDays.length === 0) {
+      throw new Error(`No competition days found for the "${classRecord.name}" competition class`);
+    }
+
+    let now = new Date();
+    let selectedDay;
+    if (now < classDays[0].date) {
+      // the competition has not started yet
+      selectedDay = classDays[0];
+    } else if (now > classDays[classDays.length - 1].date) {
+      // the competition has ended or it is the last day
+      selectedDay = classDays[classDays.length - 1];
+    } else {
+      // the competition is ongoing
+      selectedDay = toDateString(now);
+    }
+
+    this.replaceWith('strepla.competition.class.date', competition.id, classRecord.name, selectedDay);
+  }
+}

--- a/app/routes/strepla/index.js
+++ b/app/routes/strepla/index.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class extends Route {
+  async model() {
+    // TODO download the list of available competitions and show it to the user
+  }
+}

--- a/app/templates/strepla-loading.hbs
+++ b/app/templates/strepla-loading.hbs
@@ -1,0 +1,1 @@
+<Notification @text={{if (media "isMobile") "Loading..." "Loading task and competitor list..."}} class="top-centered"/>

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -1,0 +1,7 @@
+export function toDateString(date) {
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
+
+  return [year, month.toString().padStart(2, '0'), day.toString().padStart(2, '0')].join('-');
+}

--- a/app/utils/strepla-to-xcsoar.js
+++ b/app/utils/strepla-to-xcsoar.js
@@ -1,0 +1,48 @@
+export function convertTask(taskRecord) {
+  let taskType;
+  if (taskRecord.isRacing) {
+    taskType = 'RT';
+  } else if (taskRecord.isAAT) {
+    taskType = 'AAT';
+  } else {
+    throw new Error(`Unknown task type: ${taskRecord.ruleName}`);
+  }
+
+  let points = taskRecord.turnpoints.map((turnpoint, i) => {
+    let { scoring, tp } = turnpoint;
+
+    let type = i === 0 ? 'Start' : i === taskRecord.turnpoints.length - 1 ? 'Finish' : 'Turn';
+
+    let observationZone;
+    if (scoring.type === 'LINE') {
+      observationZone = `<ObservationZone type="Line" length="${scoring.width}"/>`;
+    } else if (scoring.type === 'CYLINDER') {
+      observationZone = `<ObservationZone type="Cylinder" radius="${scoring.radius}"/>`;
+    } else if (scoring.type === 'KEYHOLE') {
+      if (scoring.radiusCylinder !== 500 || scoring.radiusSector !== 10000 || scoring.angle !== 90) {
+        throw new Error(`Unsupported keyhole turnpoint type`);
+      }
+
+      observationZone = `<ObservationZone type="Keyhole"/>`;
+    } else if (scoring.type === 'AAT SECTOR') {
+      if (scoring.radial1 !== scoring.radial2) {
+        throw new Error(`Unsupported AAT sector type`);
+      }
+
+      observationZone = `<ObservationZone type="Cylinder" radius="${scoring.radius}"/>`;
+    } else {
+      throw new Error(`Unknown turnpoint type: ${scoring.type}`);
+    }
+
+    return `  <Point type="${type}">
+    <Waypoint id="${tp.id}" name="${tp.name}">
+      <Location latitude="${tp.lat}" longitude="${tp.lng}"/>
+    </Waypoint>
+    ${observationZone}
+  </Point>`;
+  });
+
+  return `<Task${taskRecord.isAAT ? ` aat_min_time="${taskRecord.minTime}"` : ''} type="${taskType}">
+${points.join('\n')}
+</Task>`;
+}

--- a/lib/ember-data-strepla/addon/urls.js
+++ b/lib/ember-data-strepla/addon/urls.js
@@ -1,1 +1,2 @@
 export const COMPETITION_LIST_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';
+export const COMPETITION_CLASS_LIST_URL = 'https://www.strepla.de/scs/ws/compclass.ashx?cmd=overview';

--- a/lib/ember-data-strepla/addon/urls.js
+++ b/lib/ember-data-strepla/addon/urls.js
@@ -2,3 +2,4 @@ export const COMPETITION_LIST_URL = 'https://www.strepla.de/scs/ws/competition.a
 export const COMPETITION_CLASS_LIST_URL = 'https://www.strepla.de/scs/ws/compclass.ashx?cmd=overview';
 export const COMPETITION_DAY_LIST_URL = 'https://www.strepla.de/scs/ws/results.ashx?cmd=overviewDays';
 export const COMPETITOR_LIST_URL = 'https://www.strepla.de/scs/ws/pilot.ashx?cmd=competitors';
+export const TASK_URL = 'https://www.strepla.de/scs/ws/results.ashx?cmd=task';

--- a/lib/ember-data-strepla/addon/urls.js
+++ b/lib/ember-data-strepla/addon/urls.js
@@ -1,2 +1,3 @@
 export const COMPETITION_LIST_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';
 export const COMPETITION_CLASS_LIST_URL = 'https://www.strepla.de/scs/ws/compclass.ashx?cmd=overview';
+export const COMPETITION_DAY_LIST_URL = 'https://www.strepla.de/scs/ws/results.ashx?cmd=overviewDays';

--- a/lib/ember-data-strepla/addon/urls.js
+++ b/lib/ember-data-strepla/addon/urls.js
@@ -1,3 +1,4 @@
 export const COMPETITION_LIST_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';
 export const COMPETITION_CLASS_LIST_URL = 'https://www.strepla.de/scs/ws/compclass.ashx?cmd=overview';
 export const COMPETITION_DAY_LIST_URL = 'https://www.strepla.de/scs/ws/results.ashx?cmd=overviewDays';
+export const COMPETITOR_LIST_URL = 'https://www.strepla.de/scs/ws/pilot.ashx?cmd=competitors';

--- a/lib/ember-data-strepla/addon/urls.js
+++ b/lib/ember-data-strepla/addon/urls.js
@@ -1,0 +1,1 @@
+export const COMPETITION_LIST_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';

--- a/lib/ember-data-strepla/app/adapters/-base.js
+++ b/lib/ember-data-strepla/app/adapters/-base.js
@@ -1,0 +1,33 @@
+import DS from 'ember-data';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter, NotFoundError, AdapterError, ConflictError, ForbiddenError, ServerError, UnauthorizedError } = DS;
+
+export default class extends Adapter {
+  async _request(url) {
+    try {
+      return await ajax(url);
+    } catch (errorResponse) {
+      if (errorResponse.status) {
+        let error;
+        if (errorResponse.status === 401) {
+          error = new UnauthorizedError();
+        } else if (errorResponse.status === 403) {
+          error = new ForbiddenError();
+        } else if (errorResponse.status === 404) {
+          error = new NotFoundError();
+        } else if (errorResponse.status === 409) {
+          error = new ConflictError();
+        } else if (errorResponse.status >= 500) {
+          error = new ServerError();
+        }
+
+        error.response = errorResponse;
+        throw error;
+      }
+
+      throw new AdapterError();
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/-base.js
+++ b/lib/ember-data-strepla/app/adapters/-base.js
@@ -1,33 +1,34 @@
 import DS from 'ember-data';
 
-import ajax from 'ember-fetch/ajax';
+import fetch from 'fetch';
 
 const { Adapter, NotFoundError, AdapterError, ConflictError, ForbiddenError, ServerError, UnauthorizedError } = DS;
 
 export default class extends Adapter {
   async _request(url) {
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      if (errorResponse.status) {
-        let error;
-        if (errorResponse.status === 401) {
-          error = new UnauthorizedError();
-        } else if (errorResponse.status === 403) {
-          error = new ForbiddenError();
-        } else if (errorResponse.status === 404) {
-          error = new NotFoundError();
-        } else if (errorResponse.status === 409) {
-          error = new ConflictError();
-        } else if (errorResponse.status >= 500) {
-          error = new ServerError();
-        }
+    let response = await fetch(url);
+    if (response.ok) {
+      return response.json();
+    }
 
-        error.response = errorResponse;
-        throw error;
+    if (response.status) {
+      let error;
+      if (response.status === 401) {
+        error = new UnauthorizedError();
+      } else if (response.status === 403) {
+        error = new ForbiddenError();
+      } else if (response.status === 404) {
+        error = new NotFoundError();
+      } else if (response.status === 409) {
+        error = new ConflictError();
+      } else if (response.status >= 500) {
+        error = new ServerError();
       }
 
-      throw new AdapterError();
+      error.response = response;
+      throw error;
     }
+
+    throw new AdapterError();
   }
 }

--- a/lib/ember-data-strepla/app/adapters/-base.js
+++ b/lib/ember-data-strepla/app/adapters/-base.js
@@ -8,7 +8,24 @@ export default class extends Adapter {
   async _request(url) {
     let response = await fetch(url);
     if (response.ok) {
-      return response.json();
+      let json = await response.json();
+
+      // The StrePla API sometimes responds with HTTP code 200, but only returns
+      // an object with a `msg` key indicating an error
+
+      if (json.msg) {
+        let error;
+        if (json.msg.indexOf('check access rights')) {
+          error = new ForbiddenError(null, json.msg);
+        } else {
+          error = new AdapterError(null, json.msg);
+        }
+
+        error.response = response;
+        throw error;
+      }
+
+      return json;
     }
 
     if (response.status) {

--- a/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
@@ -9,9 +9,11 @@ const { Adapter } = DS;
 export default class extends Adapter {
   async query(store, type, query) {
     assert('Query `type` must be `strepla-competition-class`', type.modelName === 'strepla-competition-class');
-    assert('Query must have a `competitionId` property', query.competitionId);
 
-    return await this._request(type, 'query()', query);
+    let { competitionId } = query;
+    assert('Query must have a `competitionId` property', competitionId);
+
+    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
   }
 
   async _request(type, requestType, { competitionId }) {

--- a/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
@@ -1,30 +1,16 @@
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 import { COMPETITION_CLASS_LIST_URL } from 'ember-data-strepla/urls';
 
-import ajax from 'ember-fetch/ajax';
+import BaseAdapter from './-base';
 
-const { Adapter } = DS;
-
-export default class extends Adapter {
+export default class extends BaseAdapter {
   async query(store, type, query) {
     assert('Query `type` must be `strepla-competition-class`', type.modelName === 'strepla-competition-class');
 
     let { competitionId } = query;
     assert('Query must have a `competitionId` property', competitionId);
 
-    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
-  }
-
-  async _request(type, requestType, { competitionId }) {
-    let url = `${COMPETITION_CLASS_LIST_URL}&cID=${competitionId}`;
-
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: ${requestType} failed`);
-      error.response = errorResponse;
-      throw error;
-    }
+    let classes = await this._request(`${COMPETITION_CLASS_LIST_URL}&cID=${competitionId}`);
+    return classes.map(it => ({ ...it, competitionId }));
   }
 }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition-class.js
@@ -1,0 +1,28 @@
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+import { COMPETITION_CLASS_LIST_URL } from 'ember-data-strepla/urls';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter } = DS;
+
+export default class extends Adapter {
+  async query(store, type, query) {
+    assert('Query `type` must be `strepla-competition-class`', type.modelName === 'strepla-competition-class');
+    assert('Query must have a `competitionId` property', query.competitionId);
+
+    return await this._request(type, 'query()', query);
+  }
+
+  async _request(type, requestType, { competitionId }) {
+    let url = `${COMPETITION_CLASS_LIST_URL}&cID=${competitionId}`;
+
+    try {
+      return await ajax(url);
+    } catch (errorResponse) {
+      let error = new Error(`${type.modelName}: ${requestType} failed`);
+      error.response = errorResponse;
+      throw error;
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/strepla-competition-day.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition-day.js
@@ -1,30 +1,16 @@
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 import { COMPETITION_DAY_LIST_URL } from 'ember-data-strepla/urls';
 
-import ajax from 'ember-fetch/ajax';
+import BaseAdapter from './-base';
 
-const { Adapter } = DS;
-
-export default class extends Adapter {
+export default class extends BaseAdapter {
   async query(store, type, query) {
     assert('Query `type` must be `strepla-competition-day`', type.modelName === 'strepla-competition-day');
 
     let { competitionId } = query;
     assert('Query must have a `competitionId` property', competitionId);
 
-    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
-  }
-
-  async _request(type, requestType, { competitionId }) {
-    let url = `${COMPETITION_DAY_LIST_URL}&cID=${competitionId}`;
-
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: ${requestType} failed`);
-      error.response = errorResponse;
-      throw error;
-    }
+    let days = await this._request(`${COMPETITION_DAY_LIST_URL}&cID=${competitionId}`);
+    return days.map(it => ({ ...it, competitionId }));
   }
 }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition-day.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition-day.js
@@ -1,0 +1,30 @@
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+import { COMPETITION_DAY_LIST_URL } from 'ember-data-strepla/urls';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter } = DS;
+
+export default class extends Adapter {
+  async query(store, type, query) {
+    assert('Query `type` must be `strepla-competition-day`', type.modelName === 'strepla-competition-day');
+
+    let { competitionId } = query;
+    assert('Query must have a `competitionId` property', competitionId);
+
+    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
+  }
+
+  async _request(type, requestType, { competitionId }) {
+    let url = `${COMPETITION_DAY_LIST_URL}&cID=${competitionId}`;
+
+    try {
+      return await ajax(url);
+    } catch (errorResponse) {
+      let error = new Error(`${type.modelName}: ${requestType} failed`);
+      error.response = errorResponse;
+      throw error;
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -2,24 +2,24 @@ import { assert } from '@ember/debug';
 import DS from 'ember-data';
 import { COMPETITION_LIST_URL } from 'ember-data-strepla/urls';
 
-import ajax from 'ember-fetch/ajax';
+import BaseAdapter from './-base';
 
-const { Adapter, NotFoundError } = DS;
+const { NotFoundError } = DS;
 
-export default class extends Adapter {
+export default class extends BaseAdapter {
   async findRecord(store, type, id) {
     assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
 
-    let competitions = await this._request(type, `findRecord(${id})`);
+    let competitions = await this._query();
     let competition = competitions.find(it => String(it.id) === id);
 
     if (!competition) {
-      competitions = await this._request(type, `findRecord(${id})`, { daysPeriod: 365 });
+      competitions = await this._query({ daysPeriod: 365 });
       competition = competitions.find(it => String(it.id) === id);
     }
 
     if (!competition) {
-      competitions = await this._request(type, `findRecord(${id})`, { daysPeriod: 100000 });
+      competitions = await this._query({ daysPeriod: 100000 });
       competition = competitions.find(it => String(it.id) === id);
     }
 
@@ -33,21 +33,15 @@ export default class extends Adapter {
   async query(store, type, query) {
     assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
 
-    return await this._request(type, 'query()', query);
+    return await this._query(query);
   }
 
-  async _request(type, requestType, { daysPeriod } = {}) {
+  async _query({ daysPeriod } = {}) {
     let url = COMPETITION_LIST_URL;
     if (daysPeriod) {
       url += `&daysPeriod=${daysPeriod}`;
     }
 
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: ${requestType} failed`);
-      error.response = errorResponse;
-      throw error;
-    }
+    return await this._request(url);
   }
 }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -11,10 +11,14 @@ export default class extends Adapter {
   async query(store, type /*, query */) {
     assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
 
+    return await this._request(type, 'query()');
+  }
+
+  async _request(type, requestType) {
     try {
       return await ajax(COMPETITIONS_URL);
     } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: query() failed`);
+      let error = new Error(`${type.modelName}: ${requestType} failed`);
       error.response = errorResponse;
       throw error;
     }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -3,11 +3,23 @@ import DS from 'ember-data';
 
 import ajax from 'ember-fetch/ajax';
 
-const { Adapter } = DS;
+const { Adapter, NotFoundError } = DS;
 
 export const COMPETITIONS_URL = 'http://www.strepla.de/scs/ws/competition.ashx?cmd=active';
 
 export default class extends Adapter {
+  async findRecord(store, type, id) {
+    assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
+
+    let competitions = await this._request(type, `findRecord(${id})`);
+    let competition = competitions.find(it => String(it.id) === id);
+    if (!competition) {
+      throw new NotFoundError(null, `Competition with ID ${id} could not be found`);
+    }
+
+    return competition;
+  }
+
   async query(store, type /*, query */) {
     assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
 

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -5,7 +5,7 @@ import ajax from 'ember-fetch/ajax';
 
 const { Adapter, NotFoundError } = DS;
 
-export const COMPETITIONS_URL = 'http://www.strepla.de/scs/ws/competition.ashx?cmd=active';
+export const COMPETITIONS_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';
 
 export default class extends Adapter {
   async findRecord(store, type, id) {

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -20,15 +20,20 @@ export default class extends Adapter {
     return competition;
   }
 
-  async query(store, type /*, query */) {
+  async query(store, type, query) {
     assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
 
-    return await this._request(type, 'query()');
+    return await this._request(type, 'query()', query);
   }
 
-  async _request(type, requestType) {
+  async _request(type, requestType, { daysPeriod } = {}) {
+    let url = COMPETITIONS_URL;
+    if (daysPeriod) {
+      url += `&daysPeriod=${daysPeriod}`;
+    }
+
     try {
-      return await ajax(COMPETITIONS_URL);
+      return await ajax(url);
     } catch (errorResponse) {
       let error = new Error(`${type.modelName}: ${requestType} failed`);
       error.response = errorResponse;

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -13,6 +13,17 @@ export default class extends Adapter {
 
     let competitions = await this._request(type, `findRecord(${id})`);
     let competition = competitions.find(it => String(it.id) === id);
+
+    if (!competition) {
+      competitions = await this._request(type, `findRecord(${id})`, { daysPeriod: 365 });
+      competition = competitions.find(it => String(it.id) === id);
+    }
+
+    if (!competition) {
+      competitions = await this._request(type, `findRecord(${id})`, { daysPeriod: 100000 });
+      competition = competitions.find(it => String(it.id) === id);
+    }
+
     if (!competition) {
       throw new NotFoundError(null, `Competition with ID ${id} could not be found`);
     }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -1,11 +1,10 @@
 import { assert } from '@ember/debug';
 import DS from 'ember-data';
+import { COMPETITION_LIST_URL } from 'ember-data-strepla/urls';
 
 import ajax from 'ember-fetch/ajax';
 
 const { Adapter, NotFoundError } = DS;
-
-export const COMPETITIONS_URL = 'https://www.strepla.de/scs/ws/competition.ashx?cmd=active';
 
 export default class extends Adapter {
   async findRecord(store, type, id) {
@@ -38,7 +37,7 @@ export default class extends Adapter {
   }
 
   async _request(type, requestType, { daysPeriod } = {}) {
-    let url = COMPETITIONS_URL;
+    let url = COMPETITION_LIST_URL;
     if (daysPeriod) {
       url += `&daysPeriod=${daysPeriod}`;
     }

--- a/lib/ember-data-strepla/app/adapters/strepla-competition.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competition.js
@@ -1,0 +1,22 @@
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter } = DS;
+
+export const COMPETITIONS_URL = 'http://www.strepla.de/scs/ws/competition.ashx?cmd=active';
+
+export default class extends Adapter {
+  async query(store, type /*, query */) {
+    assert('Query `type` must be `strepla-competition`', type.modelName === 'strepla-competition');
+
+    try {
+      return await ajax(COMPETITIONS_URL);
+    } catch (errorResponse) {
+      let error = new Error(`${type.modelName}: query() failed`);
+      error.response = errorResponse;
+      throw error;
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/strepla-competitor.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competitor.js
@@ -1,0 +1,30 @@
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+import { COMPETITOR_LIST_URL } from 'ember-data-strepla/urls';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter } = DS;
+
+export default class extends Adapter {
+  async query(store, type, query) {
+    assert('Query `type` must be `strepla-competitor`', type.modelName === 'strepla-competitor');
+
+    let { competitionId } = query;
+    assert('Query must have a `competitionId` property', competitionId);
+
+    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
+  }
+
+  async _request(type, requestType, { competitionId }) {
+    let url = `${COMPETITOR_LIST_URL}&cID=${competitionId}`;
+
+    try {
+      return await ajax(url);
+    } catch (errorResponse) {
+      let error = new Error(`${type.modelName}: ${requestType} failed`);
+      error.response = errorResponse;
+      throw error;
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/strepla-competitor.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competitor.js
@@ -13,7 +13,13 @@ export default class extends Adapter {
     let { competitionId } = query;
     assert('Query must have a `competitionId` property', competitionId);
 
-    return (await this._request(type, 'query()', query)).map(it => ({ ...it, competitionId }));
+    let competitors = await this._request(type, 'query()', query);
+
+    if (query.className) {
+      competitors = competitors.filter(it => it.className === query.className);
+    }
+
+    return competitors.map(it => ({ ...it, competitionId }));
   }
 
   async _request(type, requestType, { competitionId }) {

--- a/lib/ember-data-strepla/app/adapters/strepla-competitor.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-competitor.js
@@ -1,36 +1,21 @@
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 import { COMPETITOR_LIST_URL } from 'ember-data-strepla/urls';
 
-import ajax from 'ember-fetch/ajax';
+import BaseAdapter from './-base';
 
-const { Adapter } = DS;
-
-export default class extends Adapter {
+export default class extends BaseAdapter {
   async query(store, type, query) {
     assert('Query `type` must be `strepla-competitor`', type.modelName === 'strepla-competitor');
 
     let { competitionId } = query;
     assert('Query must have a `competitionId` property', competitionId);
 
-    let competitors = await this._request(type, 'query()', query);
+    let competitors = await this._request(`${COMPETITOR_LIST_URL}&cID=${competitionId}`);
 
     if (query.className) {
       competitors = competitors.filter(it => it.className === query.className);
     }
 
     return competitors.map(it => ({ ...it, competitionId }));
-  }
-
-  async _request(type, requestType, { competitionId }) {
-    let url = `${COMPETITOR_LIST_URL}&cID=${competitionId}`;
-
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: ${requestType} failed`);
-      error.response = errorResponse;
-      throw error;
-    }
   }
 }

--- a/lib/ember-data-strepla/app/adapters/strepla-task.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-task.js
@@ -1,0 +1,32 @@
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+import { TASK_URL } from 'ember-data-strepla/urls';
+
+import ajax from 'ember-fetch/ajax';
+
+const { Adapter } = DS;
+
+export default class extends Adapter {
+  async queryRecord(store, type, query) {
+    assert('Query `type` must be `strepla-task`', type.modelName === 'strepla-task');
+
+    let { competitionId, competitionDayId } = query;
+    assert('Query must have a `competitionId` property', competitionId);
+    assert('Query must have a `competitionDayId` property', competitionDayId);
+
+    let task = await this._request(type, 'queryRecord()', query);
+    return { ...task, competitionId, competitionDayId };
+  }
+
+  async _request(type, requestType, { competitionId, competitionDayId }) {
+    let url = `${TASK_URL}&cID=${competitionId}&idDay=${competitionDayId}`;
+
+    try {
+      return await ajax(url);
+    } catch (errorResponse) {
+      let error = new Error(`${type.modelName}: ${requestType} failed`);
+      error.response = errorResponse;
+      throw error;
+    }
+  }
+}

--- a/lib/ember-data-strepla/app/adapters/strepla-task.js
+++ b/lib/ember-data-strepla/app/adapters/strepla-task.js
@@ -1,12 +1,9 @@
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 import { TASK_URL } from 'ember-data-strepla/urls';
 
-import ajax from 'ember-fetch/ajax';
+import BaseAdapter from './-base';
 
-const { Adapter } = DS;
-
-export default class extends Adapter {
+export default class extends BaseAdapter {
   async queryRecord(store, type, query) {
     assert('Query `type` must be `strepla-task`', type.modelName === 'strepla-task');
 
@@ -14,19 +11,7 @@ export default class extends Adapter {
     assert('Query must have a `competitionId` property', competitionId);
     assert('Query must have a `competitionDayId` property', competitionDayId);
 
-    let task = await this._request(type, 'queryRecord()', query);
+    let task = await this._request(`${TASK_URL}&cID=${competitionId}&idDay=${competitionDayId}`);
     return { ...task, competitionId, competitionDayId };
-  }
-
-  async _request(type, requestType, { competitionId, competitionDayId }) {
-    let url = `${TASK_URL}&cID=${competitionId}&idDay=${competitionDayId}`;
-
-    try {
-      return await ajax(url);
-    } catch (errorResponse) {
-      let error = new Error(`${type.modelName}: ${requestType} failed`);
-      error.response = errorResponse;
-      throw error;
-    }
   }
 }

--- a/lib/ember-data-strepla/app/models/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/models/strepla-competition-class.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default class extends Model {
+  @attr() name;
+  @attr() ruleName;
+}

--- a/lib/ember-data-strepla/app/models/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/models/strepla-competition-class.js
@@ -1,8 +1,10 @@
 import DS from 'ember-data';
 
-const { Model, attr } = DS;
+const { Model, attr, belongsTo } = DS;
 
 export default class extends Model {
   @attr() name;
   @attr() ruleName;
+
+  @belongsTo('strepla-competition', { inverse: null }) competition;
 }

--- a/lib/ember-data-strepla/app/models/strepla-competition-day.js
+++ b/lib/ember-data-strepla/app/models/strepla-competition-day.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+const { Model, attr, belongsTo } = DS;
+
+export default class extends Model {
+  @attr() className;
+  @attr('strepla-date') date;
+  @attr('number') state;
+  @attr() stateDescription;
+
+  @belongsTo('strepla-competition', { inverse: null }) competition;
+  @belongsTo('strepla-competition-class', { inverse: null }) class;
+}

--- a/lib/ember-data-strepla/app/models/strepla-competition.js
+++ b/lib/ember-data-strepla/app/models/strepla-competition.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default class extends Model {
+  @attr() name;
+  @attr() location;
+  @attr('strepla-date') firstDay;
+  @attr('strepla-date') lastDay;
+  @attr() logoFilename;
+}

--- a/lib/ember-data-strepla/app/models/strepla-competitor.js
+++ b/lib/ember-data-strepla/app/models/strepla-competitor.js
@@ -1,0 +1,22 @@
+import DS from 'ember-data';
+
+const { Model, attr, belongsTo } = DS;
+
+export default class extends Model {
+  @attr() name;
+  @attr() country;
+
+  @attr() type;
+  @attr() registration;
+  @attr() callsign;
+  @attr('number') handicap;
+
+  @attr() flarmID;
+  @attr() logger1;
+  @attr() logger2;
+  @attr() logger3;
+
+  @attr() className;
+
+  @belongsTo('strepla-competition', { inverse: null }) competition;
+}

--- a/lib/ember-data-strepla/app/models/strepla-task.js
+++ b/lib/ember-data-strepla/app/models/strepla-task.js
@@ -6,6 +6,7 @@ export default class extends Model {
   @attr() name;
   @attr() distance;
   @attr() ruleName;
+  @attr('strepla-duration') minTime;
   @attr() turnpoints;
 
   @belongsTo('strepla-competition', { inverse: null }) competition;

--- a/lib/ember-data-strepla/app/models/strepla-task.js
+++ b/lib/ember-data-strepla/app/models/strepla-task.js
@@ -1,3 +1,4 @@
+import { equal } from '@ember/object/computed';
 import DS from 'ember-data';
 
 const { Model, attr, belongsTo } = DS;
@@ -8,6 +9,9 @@ export default class extends Model {
   @attr() ruleName;
   @attr('strepla-duration') minTime;
   @attr() turnpoints;
+
+  @equal('ruleName', 'Racing-Task (RT)') isRacing;
+  @equal('ruleName', 'Speed Assigned Area Task (AAT)') isAAT;
 
   @belongsTo('strepla-competition', { inverse: null }) competition;
   @belongsTo('strepla-competition-day', { inverse: null }) competitionDay;

--- a/lib/ember-data-strepla/app/models/strepla-task.js
+++ b/lib/ember-data-strepla/app/models/strepla-task.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+const { Model, attr, belongsTo } = DS;
+
+export default class extends Model {
+  @attr() name;
+  @attr() distance;
+  @attr() ruleName;
+  @attr() turnpoints;
+
+  @belongsTo('strepla-competition', { inverse: null }) competition;
+  @belongsTo('strepla-competition-day', { inverse: null }) competitionDay;
+}

--- a/lib/ember-data-strepla/app/serializers/-base.js
+++ b/lib/ember-data-strepla/app/serializers/-base.js
@@ -1,0 +1,29 @@
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+
+const { Serializer } = DS;
+
+export default class extends Serializer {
+  applyTransforms(typeClass, data) {
+    let attributes = typeClass.attributes;
+
+    typeClass.eachTransformedAttribute((key, typeClass) => {
+      if (data[key] !== undefined) {
+        let transform = this.transformFor(typeClass);
+        let transformMeta = attributes.get(key);
+        data[key] = transform.deserialize(data[key], transformMeta.options);
+      }
+    });
+
+    return data;
+  }
+
+  transformFor(attributeType) {
+    let transform = getOwner(this).lookup(`transform:${attributeType}`);
+
+    assert(`Unable to find the transform for \`attr('${attributeType}')\``, transform);
+
+    return transform;
+  }
+}

--- a/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
@@ -1,10 +1,8 @@
-import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 
-const { Serializer } = DS;
+import BaseSerializer from './-base';
 
-export default class extends Serializer {
+export default class extends BaseSerializer {
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     assert(`Unknown \`requestType\`: ${requestType}`, ['query'].indexOf(requestType) !== -1);
 
@@ -32,27 +30,5 @@ export default class extends Serializer {
     this.applyTransforms(modelClass, data.attributes);
 
     return { data, included: [] };
-  }
-
-  applyTransforms(typeClass, data) {
-    let attributes = typeClass.attributes;
-
-    typeClass.eachTransformedAttribute((key, typeClass) => {
-      if (data[key] !== undefined) {
-        let transform = this.transformFor(typeClass);
-        let transformMeta = attributes.get(key);
-        data[key] = transform.deserialize(data[key], transformMeta.options);
-      }
-    });
-
-    return data;
-  }
-
-  transformFor(attributeType) {
-    let transform = getOwner(this).lookup(`transform:${attributeType}`);
-
-    assert(`Unable to find the transform for \`attr('${attributeType}')\``, transform);
-
-    return transform;
   }
 }

--- a/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
@@ -1,0 +1,58 @@
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+
+const { Serializer } = DS;
+
+export default class extends Serializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    assert(`Unknown \`requestType\`: ${requestType}`, ['query'].indexOf(requestType) !== -1);
+
+    return payload.reduce(
+      (documentHash, item) => {
+        let { data, included } = this.normalize(primaryModelClass, item);
+        documentHash.included.push(...included);
+        documentHash.data.push(data);
+        return documentHash;
+      },
+      { data: [], included: [] },
+    );
+  }
+
+  normalize(modelClass, resourceHash) {
+    let data = {
+      id: resourceHash.id,
+      type: modelClass.modelName,
+      attributes: {
+        name: resourceHash.name,
+        ruleName: resourceHash.rulename,
+      },
+    };
+
+    this.applyTransforms(modelClass, data.attributes);
+
+    return { data, included: [] };
+  }
+
+  applyTransforms(typeClass, data) {
+    let attributes = typeClass.attributes;
+
+    typeClass.eachTransformedAttribute((key, typeClass) => {
+      if (data[key] !== undefined) {
+        let transform = this.transformFor(typeClass);
+        let transformMeta = attributes.get(key);
+        data[key] = transform.deserialize(data[key], transformMeta.options);
+      }
+    });
+
+    return data;
+  }
+
+  transformFor(attributeType) {
+    let transform = getOwner(this).lookup(`transform:${attributeType}`);
+
+    assert(`Unable to find the transform for \`attr('${attributeType}')\``, transform);
+
+    return transform;
+  }
+}

--- a/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition-class.js
@@ -27,6 +27,17 @@ export default class extends BaseSerializer {
       },
     };
 
+    if ('competitionId' in resourceHash) {
+      data.relationships = {
+        competition: {
+          data: {
+            id: resourceHash.competitionId,
+            type: 'strepla-competition',
+          },
+        },
+      };
+    }
+
     this.applyTransforms(modelClass, data.attributes);
 
     return { data, included: [] };

--- a/lib/ember-data-strepla/app/serializers/strepla-competition-day.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition-day.js
@@ -1,0 +1,53 @@
+import { assert } from '@ember/debug';
+
+import BaseSerializer from './-base';
+
+export default class extends BaseSerializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    assert(`Unknown \`requestType\`: ${requestType}`, ['query'].indexOf(requestType) !== -1);
+
+    return payload.reduce(
+      (documentHash, item) => {
+        let { data, included } = this.normalize(primaryModelClass, item);
+        documentHash.included.push(...included);
+        documentHash.data.push(data);
+        return documentHash;
+      },
+      { data: [], included: [] },
+    );
+  }
+
+  normalize(modelClass, resourceHash) {
+    let data = {
+      id: resourceHash.idCD,
+      type: modelClass.modelName,
+      attributes: {
+        date: resourceHash.date,
+        className: resourceHash.nameCC,
+        state: resourceHash.state,
+        stateDescription: resourceHash.sState,
+      },
+      relationships: {
+        class: {
+          data: {
+            id: resourceHash.idCC,
+            type: 'strepla-competition-class',
+          },
+        },
+      },
+    };
+
+    if ('competitionId' in resourceHash) {
+      data.relationships.competition = {
+        data: {
+          id: resourceHash.competitionId,
+          type: 'strepla-competition',
+        },
+      };
+    }
+
+    this.applyTransforms(modelClass, data.attributes);
+
+    return { data, included: [] };
+  }
+}

--- a/lib/ember-data-strepla/app/serializers/strepla-competition.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition.js
@@ -1,0 +1,61 @@
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+import DS from 'ember-data';
+
+const { Serializer } = DS;
+
+export default class extends Serializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    assert('Unknown `requestType`', requestType === 'query');
+
+    return payload.reduce(
+      (documentHash, item) => {
+        let { data, included } = this.normalize(primaryModelClass, item);
+        documentHash.included.push(...included);
+        documentHash.data.push(data);
+        return documentHash;
+      },
+      { data: [], included: [] },
+    );
+  }
+
+  normalize(modelClass, resourceHash) {
+    let data = {
+      id: resourceHash.id,
+      type: modelClass.modelName,
+      attributes: {
+        name: resourceHash.name,
+        location: resourceHash.Location,
+        firstDay: resourceHash.firstDay,
+        lastDay: resourceHash.lastDay,
+        logoFilename: resourceHash.fnLogo || null,
+      },
+    };
+
+    this.applyTransforms(modelClass, data.attributes);
+
+    return { data, included: [] };
+  }
+
+  applyTransforms(typeClass, data) {
+    let attributes = typeClass.attributes;
+
+    typeClass.eachTransformedAttribute((key, typeClass) => {
+      if (data[key] !== undefined) {
+        let transform = this.transformFor(typeClass);
+        let transformMeta = attributes.get(key);
+        data[key] = transform.deserialize(data[key], transformMeta.options);
+      }
+    });
+
+    return data;
+  }
+
+  transformFor(attributeType) {
+    let transform = getOwner(this).lookup(`transform:${attributeType}`);
+
+    assert(`Unable to find the transform for \`attr('${attributeType}')\``, transform);
+
+    return transform;
+  }
+}

--- a/lib/ember-data-strepla/app/serializers/strepla-competition.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition.js
@@ -1,10 +1,8 @@
-import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
-import DS from 'ember-data';
 
-const { Serializer } = DS;
+import BaseSerializer from './-base';
 
-export default class extends Serializer {
+export default class extends BaseSerializer {
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     assert(`Unknown \`requestType\`: ${requestType}`, ['query', 'findRecord'].indexOf(requestType) !== -1);
 
@@ -39,27 +37,5 @@ export default class extends Serializer {
     this.applyTransforms(modelClass, data.attributes);
 
     return { data, included: [] };
-  }
-
-  applyTransforms(typeClass, data) {
-    let attributes = typeClass.attributes;
-
-    typeClass.eachTransformedAttribute((key, typeClass) => {
-      if (data[key] !== undefined) {
-        let transform = this.transformFor(typeClass);
-        let transformMeta = attributes.get(key);
-        data[key] = transform.deserialize(data[key], transformMeta.options);
-      }
-    });
-
-    return data;
-  }
-
-  transformFor(attributeType) {
-    let transform = getOwner(this).lookup(`transform:${attributeType}`);
-
-    assert(`Unable to find the transform for \`attr('${attributeType}')\``, transform);
-
-    return transform;
   }
 }

--- a/lib/ember-data-strepla/app/serializers/strepla-competition.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competition.js
@@ -6,7 +6,11 @@ const { Serializer } = DS;
 
 export default class extends Serializer {
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
-    assert('Unknown `requestType`', requestType === 'query');
+    assert(`Unknown \`requestType\`: ${requestType}`, ['query', 'findRecord'].indexOf(requestType) !== -1);
+
+    if (requestType === 'findRecord') {
+      return this.normalize(primaryModelClass, payload);
+    }
 
     return payload.reduce(
       (documentHash, item) => {

--- a/lib/ember-data-strepla/app/serializers/strepla-competitor.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-competitor.js
@@ -1,0 +1,51 @@
+import { assert } from '@ember/debug';
+
+import BaseSerializer from './-base';
+
+export default class extends BaseSerializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    assert(`Unknown \`requestType\`: ${requestType}`, ['query'].indexOf(requestType) !== -1);
+
+    return payload.reduce(
+      (documentHash, item) => {
+        let { data, included } = this.normalize(primaryModelClass, item);
+        documentHash.included.push(...included);
+        documentHash.data.push(data);
+        return documentHash;
+      },
+      { data: [], included: [] },
+    );
+  }
+
+  normalize(modelClass, resourceHash) {
+    let data = {
+      id: `${resourceHash.competitionId}-${resourceHash.id}`,
+      type: modelClass.modelName,
+      attributes: {
+        name: resourceHash.name,
+        country: resourceHash.country,
+        type: resourceHash.glider_name,
+        registration: resourceHash.glider_callsign,
+        callsign: resourceHash.glider_cid,
+        handicap: resourceHash.glider_index,
+        flarmID: resourceHash.flarm_ID,
+        logger1: resourceHash.logger1,
+        logger2: resourceHash.logger2,
+        logger3: resourceHash.logger3,
+        className: resourceHash.className,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: resourceHash.competitionId,
+            type: 'strepla-competition',
+          },
+        },
+      },
+    };
+
+    this.applyTransforms(modelClass, data.attributes);
+
+    return { data, included: [] };
+  }
+}

--- a/lib/ember-data-strepla/app/serializers/strepla-task.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-task.js
@@ -18,6 +18,7 @@ export default class extends BaseSerializer {
         distance: resourceHash.distance,
         numLegs: resourceHash.numLegs,
         ruleName: resourceHash.rule,
+        minTime: resourceHash.min_time || null,
         turnpoints: resourceHash.tps,
       },
       relationships: {

--- a/lib/ember-data-strepla/app/serializers/strepla-task.js
+++ b/lib/ember-data-strepla/app/serializers/strepla-task.js
@@ -1,0 +1,43 @@
+import { assert } from '@ember/debug';
+
+import BaseSerializer from './-base';
+
+export default class extends BaseSerializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    assert(`Unknown \`requestType\`: ${requestType}`, ['queryRecord'].indexOf(requestType) !== -1);
+
+    return this.normalize(primaryModelClass, payload);
+  }
+
+  normalize(modelClass, resourceHash) {
+    let data = {
+      id: resourceHash.id,
+      type: modelClass.modelName,
+      attributes: {
+        name: resourceHash.name,
+        distance: resourceHash.distance,
+        numLegs: resourceHash.numLegs,
+        ruleName: resourceHash.rule,
+        turnpoints: resourceHash.tps,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: resourceHash.competitionId,
+            type: 'strepla-competition',
+          },
+        },
+        competitionDay: {
+          data: {
+            id: resourceHash.competitionDayId,
+            type: 'strepla-competition-day',
+          },
+        },
+      },
+    };
+
+    this.applyTransforms(modelClass, data.attributes);
+
+    return { data, included: [] };
+  }
+}

--- a/lib/ember-data-strepla/app/transforms/strepla-date.js
+++ b/lib/ember-data-strepla/app/transforms/strepla-date.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+
+const { Transform } = DS;
+
+export default class extends Transform {
+  deserialize(serialized) {
+    let time = Date.parse(serialized);
+    if (isNaN(time)) {
+      throw new Error(`Invalid date: ${serialized}`);
+    }
+
+    return new Date(time);
+  }
+}

--- a/lib/ember-data-strepla/app/transforms/strepla-duration.js
+++ b/lib/ember-data-strepla/app/transforms/strepla-duration.js
@@ -1,0 +1,22 @@
+import DS from 'ember-data';
+
+const { Transform } = DS;
+
+const RE_DURATION = /^(\d+):([0-5]\d)$/;
+
+/**
+ * Parses strings like "02:34" into `154` (2 hours + 34 minutes).
+ */
+export default class extends Transform {
+  deserialize(serialized) {
+    if (!serialized) return null;
+    if (typeof serialized !== 'string') throw new Error(`Invalid duration: ${serialized}`);
+
+    let match = serialized.match(RE_DURATION);
+    if (!match) throw new Error(`Invalid duration: ${serialized}`);
+
+    let hh = parseInt(match[1], 10);
+    let mm = parseInt(match[2], 10);
+    return hh * 60 + mm;
+  }
+}

--- a/lib/ember-data-strepla/index.js
+++ b/lib/ember-data-strepla/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+};

--- a/lib/ember-data-strepla/package.json
+++ b/lib/ember-data-strepla/package.json
@@ -5,5 +5,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "*"
+  },
+  "peerDependencies": {
+    "ember-data": "^3.9.1"
   }
 }

--- a/lib/ember-data-strepla/package.json
+++ b/lib/ember-data-strepla/package.json
@@ -7,6 +7,7 @@
     "ember-cli-babel": "*"
   },
   "peerDependencies": {
+    "ember-fetch": "*",
     "ember-data": "^3.9.1"
   }
 }

--- a/lib/ember-data-strepla/package.json
+++ b/lib/ember-data-strepla/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ember-data-strepla",
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "ember-addon": {
     "paths": [
+      "lib/ember-data-strepla",
       "lib/freestyle",
       "lib/igc-replay"
     ]

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-concurrency": "^1.0.0",
     "ember-concurrency-decorators": "^1.0.0-beta.4",
     "ember-css-modules": "^1.2.1",
+    "ember-data": "^3.9.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^6.7.0",
     "ember-freestyle": "^0.10.0",

--- a/tests/ember-data-strepla/strepla-competition-class-test.js
+++ b/tests/ember-data-strepla/strepla-competition-class-test.js
@@ -57,7 +57,7 @@ module('ember-data-strepla | strepla-competition-class', function(hooks) {
         await this.store.query('strepla-competition-class', { competitionId: 577 });
         assert.fail('query() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-competition-class: query() failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competition-class').length, 0);
       }

--- a/tests/ember-data-strepla/strepla-competition-class-test.js
+++ b/tests/ember-data-strepla/strepla-competition-class-test.js
@@ -1,0 +1,66 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { COMPETITION_CLASS_LIST_URL } from 'ember-data-strepla/urls';
+
+import { setupQunit as setupPolly } from '@pollyjs/core';
+
+module('ember-data-strepla | strepla-competition-class', function(hooks) {
+  setupTest(hooks);
+  setupPolly(hooks, { recordIfMissing: false });
+
+  hooks.beforeEach(function() {
+    this.server = this.polly.server;
+    this.store = this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.server.get(COMPETITION_CLASS_LIST_URL).intercept((req, res) => {
+      let classes = [];
+
+      if (req.query.cID === '577') {
+        classes.push(
+          { id: 856, name: 'Gem.', rulename: '1000 Punkte Handicap' },
+          { id: 868, name: '18m', rulename: '1000 Punkte Handicap' },
+        );
+      }
+
+      return res.status(200).send(classes);
+    });
+  });
+
+  module('query()', function() {
+    test('requests data from the API and transforms it to Ember Data models', async function(assert) {
+      let records = await this.store.query('strepla-competition-class', { competitionId: 577 });
+
+      assert.equal(records.length, 2);
+
+      let c1 = records.objectAt(0);
+      assert.strictEqual(c1.id, '856');
+      assert.equal(c1.name, 'Gem.');
+      assert.equal(c1.ruleName, '1000 Punkte Handicap');
+
+      let c2 = records.objectAt(1);
+      assert.strictEqual(c2.id, '868');
+      assert.equal(c2.name, '18m');
+    });
+
+    test('caches Ember Data models in the store', async function(assert) {
+      await this.store.query('strepla-competition-class', { competitionId: 577 });
+      assert.equal(this.store.peekAll('strepla-competition-class').length, 2);
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server.get(COMPETITION_CLASS_LIST_URL).intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.query('strepla-competition-class', { competitionId: 577 });
+        assert.fail('query() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-competition-class: query() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-competition-class').length, 0);
+      }
+    });
+  });
+});

--- a/tests/ember-data-strepla/strepla-competition-class-test.js
+++ b/tests/ember-data-strepla/strepla-competition-class-test.js
@@ -1,7 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { COMPETITION_CLASS_LIST_URL } from 'ember-data-strepla/urls';
+import { COMPETITION_LIST_URL, COMPETITION_CLASS_LIST_URL } from 'ember-data-strepla/urls';
 
 import { setupQunit as setupPolly } from '@pollyjs/core';
 
@@ -62,5 +62,28 @@ module('ember-data-strepla | strepla-competition-class', function(hooks) {
         assert.equal(this.store.peekAll('strepla-competition-class').length, 0);
       }
     });
+  });
+
+  test('has an async `competition` relationship', async function(assert) {
+    this.server.get(COMPETITION_LIST_URL).intercept((req, res) =>
+      res.status(200).send([
+        {
+          id: 577,
+          name: 'EuregioCup 2019',
+          Location: 'Aachen-Merzbrück',
+          firstDay: '2019-06-06T00:00:00',
+          lastDay: '2019-06-10T00:00:00',
+          fnLogo: '',
+        },
+      ]),
+    );
+
+    let records = await this.store.query('strepla-competition-class', { competitionId: 577 });
+
+    let c1 = records.objectAt(0);
+    assert.strictEqual(c1.id, '856');
+
+    let competition = await c1.competition;
+    assert.equal(competition.name, 'EuregioCup 2019');
   });
 });

--- a/tests/ember-data-strepla/strepla-competition-day-test.js
+++ b/tests/ember-data-strepla/strepla-competition-day-test.js
@@ -1,0 +1,132 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { COMPETITION_LIST_URL, COMPETITION_DAY_LIST_URL } from 'ember-data-strepla/urls';
+
+import { setupQunit as setupPolly } from '@pollyjs/core';
+
+module('ember-data-strepla | strepla-competition-day', function(hooks) {
+  setupTest(hooks);
+  setupPolly(hooks, { recordIfMissing: false });
+
+  hooks.beforeEach(function() {
+    this.server = this.polly.server;
+    this.store = this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.server.get(COMPETITION_DAY_LIST_URL).intercept((req, res) => {
+      let classes = [];
+
+      if (req.query.cID === '577') {
+        classes.push(
+          {
+            DT_RowId: 1,
+            idCD: '5377',
+            date: '2017-04-05T00:00:00',
+            idCC: '856',
+            nameCC: 'Gem.',
+            state: '0',
+            sState: 'Ungeplant',
+          },
+          {
+            DT_RowId: 2,
+            idCD: '5380',
+            date: '2017-04-05T00:00:00',
+            idCC: '868',
+            nameCC: '18m',
+            state: '60',
+            sState: 'Neutralisiert',
+          },
+          {
+            DT_RowId: 3,
+            idCD: '5383',
+            date: '2017-04-06T00:00:00',
+            idCC: '856',
+            nameCC: 'Gem.',
+            state: '50',
+            sState: 'Endgültige Wertung',
+          },
+          {
+            DT_RowId: 4,
+            idCD: '5386',
+            date: '2017-04-06T00:00:00',
+            idCC: '868',
+            nameCC: '18m',
+            state: '50',
+            sState: 'Endgültige Wertung',
+          },
+        );
+      }
+
+      return res.status(200).send(classes);
+    });
+  });
+
+  module('query()', function() {
+    test('requests data from the API and transforms it to Ember Data models', async function(assert) {
+      let records = await this.store.query('strepla-competition-day', { competitionId: 577 });
+
+      assert.equal(records.length, 4);
+
+      let c1 = records.objectAt(0);
+      assert.strictEqual(c1.id, '5377');
+      assert.equal(c1.className, 'Gem.');
+      assert.equal(c1.date.getTime(), Date.parse('2017-04-05T00:00:00'));
+
+      let c2 = records.objectAt(1);
+      assert.strictEqual(c2.id, '5380');
+      assert.equal(c2.className, '18m');
+    });
+
+    test('caches Ember Data models in the store', async function(assert) {
+      await this.store.query('strepla-competition-day', { competitionId: 577 });
+      assert.equal(this.store.peekAll('strepla-competition-day').length, 4);
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server.get(COMPETITION_DAY_LIST_URL).intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.query('strepla-competition-day', { competitionId: 577 });
+        assert.fail('query() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-competition-day: query() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-competition-day').length, 0);
+      }
+    });
+  });
+
+  test('has an async `competition` relationship', async function(assert) {
+    this.server.get(COMPETITION_LIST_URL).intercept((req, res) =>
+      res.status(200).send([
+        {
+          id: 577,
+          name: 'EuregioCup 2019',
+          Location: 'Aachen-Merzbrück',
+          firstDay: '2019-06-06T00:00:00',
+          lastDay: '2019-06-10T00:00:00',
+          fnLogo: '',
+        },
+      ]),
+    );
+
+    let records = await this.store.query('strepla-competition-day', { competitionId: 577 });
+    let record = records.objectAt(0);
+
+    let competition = await record.competition;
+    assert.equal(competition.name, 'EuregioCup 2019');
+  });
+
+  test('has an async `class` relationship', async function(assert) {
+    let records = await this.store.query('strepla-competition-day', { competitionId: 577 });
+    let record = records.objectAt(0);
+
+    // `await record.class` does not work because `findRecord()` is not implemented for
+    // the `strepla-competition-class` adapter, but at least we can access the ID
+    // of the related record
+
+    assert.equal(record.belongsTo('class').id(), '856');
+  });
+});

--- a/tests/ember-data-strepla/strepla-competition-day-test.js
+++ b/tests/ember-data-strepla/strepla-competition-day-test.js
@@ -91,7 +91,7 @@ module('ember-data-strepla | strepla-competition-day', function(hooks) {
         await this.store.query('strepla-competition-day', { competitionId: 577 });
         assert.fail('query() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-competition-day: query() failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competition-day').length, 0);
       }

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -132,6 +132,13 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
       assert.strictEqual(record.logoFilename, null);
     });
 
+    test('finds past competitions too', async function(assert) {
+      let record = await this.store.findRecord('strepla-competition', 571);
+
+      assert.ok(record);
+      assert.strictEqual(record.id, '571');
+    });
+
     test('caches Ember Data models in the store', async function(assert) {
       await this.store.findRecord('strepla-competition', 577);
 

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -1,0 +1,96 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { setupQunit as setupPolly } from '@pollyjs/core';
+
+module('ember-data-strepla | strepla-competition', function(hooks) {
+  setupTest(hooks);
+  setupPolly(hooks, { recordIfMissing: false });
+
+  hooks.beforeEach(function() {
+    this.server = this.polly.server;
+    this.store = this.owner.lookup('service:store');
+  });
+
+  module('query()', function(hooks) {
+    hooks.beforeEach(function() {
+      this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) =>
+        res.status(200).send([
+          {
+            id: 577,
+            name: 'EuregioCup 2019',
+            Location: 'Aachen-Merzbrück',
+            firstDay: '2019-06-06T00:00:00',
+            lastDay: '2019-06-10T00:00:00',
+            fnLogo: '',
+          },
+          {
+            id: 571,
+            name: 'DM Club- und Standardklasse 2017',
+            Location: 'VLP Zwickau',
+            firstDay: '2017-05-20T00:00:00',
+            lastDay: '2017-05-31T00:00:00',
+            fnLogo: 'logo.png',
+          },
+          {
+            id: 487,
+            name: 'Internationaler Bayreuth Wettbewerb 2018',
+            Location: 'Bayreuth-Bindlacher Berg (EDQD)',
+            firstDay: '2018-05-23T00:00:00',
+            lastDay: '2018-06-01T00:00:00',
+            fnLogo: 'logo.jpg',
+          },
+        ]),
+      );
+    });
+
+    test('requests data from the API and transforms it to Ember Data models', async function(assert) {
+      let records = await this.store.query('strepla-competition', {});
+
+      assert.equal(records.length, 3);
+
+      let comp1 = records.objectAt(0);
+      assert.strictEqual(comp1.id, '577');
+      assert.equal(comp1.name, 'EuregioCup 2019');
+      assert.equal(comp1.location, 'Aachen-Merzbrück');
+      assert.equal(comp1.firstDay.getTime(), Date.parse('2019-06-06T00:00:00'));
+      assert.equal(comp1.lastDay.getTime(), Date.parse('2019-06-10T00:00:00'));
+      assert.strictEqual(comp1.logoFilename, null);
+
+      let comp2 = records.objectAt(1);
+      assert.strictEqual(comp2.id, '571');
+      assert.equal(comp2.name, 'DM Club- und Standardklasse 2017');
+      assert.equal(comp2.logoFilename, 'logo.png');
+
+      let comp3 = records.objectAt(2);
+      assert.strictEqual(comp3.id, '487');
+    });
+
+    test('caches Ember Data models in the store', async function(assert) {
+      await this.store.query('strepla-competition', {});
+
+      assert.equal(this.store.peekAll('strepla-competition').length, 3);
+
+      let comp = this.store.peekRecord('strepla-competition', '577');
+      assert.strictEqual(comp.id, '577');
+      assert.equal(comp.name, 'EuregioCup 2019');
+
+      assert.strictEqual(this.store.peekRecord('strepla-competition', '123'), null);
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server
+        .get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active')
+        .intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.query('strepla-competition', {});
+        assert.fail('query() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-competition: query() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-competition').length, 0);
+      }
+    });
+  });
+});

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -2,6 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import DS from 'ember-data';
+import { COMPETITION_LIST_URL } from 'ember-data-strepla/urls';
 
 import { setupQunit as setupPolly } from '@pollyjs/core';
 
@@ -17,7 +18,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
   });
 
   hooks.beforeEach(function() {
-    this.server.get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) => {
+    this.server.get(COMPETITION_LIST_URL).intercept((req, res) => {
       let competitions = [
         {
           id: 577,
@@ -104,9 +105,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
     });
 
     test('throws an error if the server responds with an error', async function(assert) {
-      this.server
-        .get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active')
-        .intercept((req, res) => res.status(500).send());
+      this.server.get(COMPETITION_LIST_URL).intercept((req, res) => res.status(500).send());
 
       try {
         await this.store.query('strepla-competition', {});
@@ -163,9 +162,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
     });
 
     test('throws an error if the server responds with an error', async function(assert) {
-      this.server
-        .get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active')
-        .intercept((req, res) => res.status(500).send());
+      this.server.get(COMPETITION_LIST_URL).intercept((req, res) => res.status(500).send());
 
       try {
         await this.store.findRecord('strepla-competition', 577);

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -17,7 +17,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
   });
 
   hooks.beforeEach(function() {
-    this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) => {
+    this.server.get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) => {
       let competitions = [
         {
           id: 577,
@@ -105,7 +105,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
 
     test('throws an error if the server responds with an error', async function(assert) {
       this.server
-        .get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active')
+        .get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active')
         .intercept((req, res) => res.status(500).send());
 
       try {
@@ -164,7 +164,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
 
     test('throws an error if the server responds with an error', async function(assert) {
       this.server
-        .get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active')
+        .get('https://www.strepla.de/scs/ws/competition.ashx?cmd=active')
         .intercept((req, res) => res.status(500).send());
 
       try {

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -17,8 +17,8 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
   });
 
   hooks.beforeEach(function() {
-    this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) =>
-      res.status(200).send([
+    this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) => {
+      let competitions = [
         {
           id: 577,
           name: 'EuregioCup 2019',
@@ -28,14 +28,6 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
           fnLogo: '',
         },
         {
-          id: 571,
-          name: 'DM Club- und Standardklasse 2017',
-          Location: 'VLP Zwickau',
-          firstDay: '2017-05-20T00:00:00',
-          lastDay: '2017-05-31T00:00:00',
-          fnLogo: 'logo.png',
-        },
-        {
           id: 487,
           name: 'Internationaler Bayreuth Wettbewerb 2018',
           Location: 'Bayreuth-Bindlacher Berg (EDQD)',
@@ -43,15 +35,29 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
           lastDay: '2018-06-01T00:00:00',
           fnLogo: 'logo.jpg',
         },
-      ]),
-    );
+      ];
+
+      let { daysPeriod } = req.query;
+      if (daysPeriod && daysPeriod >= 360) {
+        competitions.push({
+          id: 571,
+          name: 'DM Club- und Standardklasse 2017',
+          Location: 'VLP Zwickau',
+          firstDay: '2017-05-20T00:00:00',
+          lastDay: '2017-05-31T00:00:00',
+          fnLogo: 'logo.png',
+        });
+      }
+
+      return res.status(200).send(competitions);
+    });
   });
 
   module('query()', function() {
     test('requests data from the API and transforms it to Ember Data models', async function(assert) {
       let records = await this.store.query('strepla-competition', {});
 
-      assert.equal(records.length, 3);
+      assert.equal(records.length, 2);
 
       let comp1 = records.objectAt(0);
       assert.strictEqual(comp1.id, '577');
@@ -62,18 +68,33 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
       assert.strictEqual(comp1.logoFilename, null);
 
       let comp2 = records.objectAt(1);
-      assert.strictEqual(comp2.id, '571');
-      assert.equal(comp2.name, 'DM Club- und Standardklasse 2017');
-      assert.equal(comp2.logoFilename, 'logo.png');
+      assert.strictEqual(comp2.id, '487');
+      assert.equal(comp2.name, 'Internationaler Bayreuth Wettbewerb 2018');
+      assert.equal(comp2.logoFilename, 'logo.jpg');
+    });
+
+    test('supports the `daysPeriod` parameter', async function(assert) {
+      let records = await this.store.query('strepla-competition', { daysPeriod: 360 });
+
+      assert.equal(records.length, 3);
+
+      let comp1 = records.objectAt(0);
+      assert.strictEqual(comp1.id, '577');
+      assert.equal(comp1.name, 'EuregioCup 2019');
+
+      let comp2 = records.objectAt(1);
+      assert.strictEqual(comp2.id, '487');
+      assert.equal(comp2.name, 'Internationaler Bayreuth Wettbewerb 2018');
 
       let comp3 = records.objectAt(2);
-      assert.strictEqual(comp3.id, '487');
+      assert.strictEqual(comp3.id, '571');
+      assert.equal(comp3.name, 'DM Club- und Standardklasse 2017');
     });
 
     test('caches Ember Data models in the store', async function(assert) {
       await this.store.query('strepla-competition', {});
 
-      assert.equal(this.store.peekAll('strepla-competition').length, 3);
+      assert.equal(this.store.peekAll('strepla-competition').length, 2);
 
       let comp = this.store.peekRecord('strepla-competition', '577');
       assert.strictEqual(comp.id, '577');

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -1,7 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import DS from 'ember-data';
+
 import { setupQunit as setupPolly } from '@pollyjs/core';
+
+const { NotFoundError } = DS;
 
 module('ember-data-strepla | strepla-competition', function(hooks) {
   setupTest(hooks);
@@ -12,38 +16,38 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
     this.store = this.owner.lookup('service:store');
   });
 
-  module('query()', function(hooks) {
-    hooks.beforeEach(function() {
-      this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) =>
-        res.status(200).send([
-          {
-            id: 577,
-            name: 'EuregioCup 2019',
-            Location: 'Aachen-Merzbrück',
-            firstDay: '2019-06-06T00:00:00',
-            lastDay: '2019-06-10T00:00:00',
-            fnLogo: '',
-          },
-          {
-            id: 571,
-            name: 'DM Club- und Standardklasse 2017',
-            Location: 'VLP Zwickau',
-            firstDay: '2017-05-20T00:00:00',
-            lastDay: '2017-05-31T00:00:00',
-            fnLogo: 'logo.png',
-          },
-          {
-            id: 487,
-            name: 'Internationaler Bayreuth Wettbewerb 2018',
-            Location: 'Bayreuth-Bindlacher Berg (EDQD)',
-            firstDay: '2018-05-23T00:00:00',
-            lastDay: '2018-06-01T00:00:00',
-            fnLogo: 'logo.jpg',
-          },
-        ]),
-      );
-    });
+  hooks.beforeEach(function() {
+    this.server.get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active').intercept((req, res) =>
+      res.status(200).send([
+        {
+          id: 577,
+          name: 'EuregioCup 2019',
+          Location: 'Aachen-Merzbrück',
+          firstDay: '2019-06-06T00:00:00',
+          lastDay: '2019-06-10T00:00:00',
+          fnLogo: '',
+        },
+        {
+          id: 571,
+          name: 'DM Club- und Standardklasse 2017',
+          Location: 'VLP Zwickau',
+          firstDay: '2017-05-20T00:00:00',
+          lastDay: '2017-05-31T00:00:00',
+          fnLogo: 'logo.png',
+        },
+        {
+          id: 487,
+          name: 'Internationaler Bayreuth Wettbewerb 2018',
+          Location: 'Bayreuth-Bindlacher Berg (EDQD)',
+          firstDay: '2018-05-23T00:00:00',
+          lastDay: '2018-06-01T00:00:00',
+          fnLogo: 'logo.jpg',
+        },
+      ]),
+    );
+  });
 
+  module('query()', function() {
     test('requests data from the API and transforms it to Ember Data models', async function(assert) {
       let records = await this.store.query('strepla-competition', {});
 
@@ -88,6 +92,58 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
         assert.fail('query() unexpectedly did not fail');
       } catch (error) {
         assert.equal(error.toString(), 'Error: strepla-competition: query() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-competition').length, 0);
+      }
+    });
+  });
+
+  module('findRecord()', function() {
+    test('requests data from the API and transforms it to Ember Data models', async function(assert) {
+      let record = await this.store.findRecord('strepla-competition', 577);
+
+      assert.ok(record);
+      assert.strictEqual(record.id, '577');
+      assert.equal(record.name, 'EuregioCup 2019');
+      assert.equal(record.location, 'Aachen-Merzbrück');
+      assert.equal(record.firstDay.getTime(), Date.parse('2019-06-06T00:00:00'));
+      assert.equal(record.lastDay.getTime(), Date.parse('2019-06-10T00:00:00'));
+      assert.strictEqual(record.logoFilename, null);
+    });
+
+    test('caches Ember Data models in the store', async function(assert) {
+      await this.store.findRecord('strepla-competition', 577);
+
+      assert.equal(this.store.peekAll('strepla-competition').length, 1);
+
+      let comp = this.store.peekRecord('strepla-competition', '577');
+      assert.strictEqual(comp.id, '577');
+      assert.equal(comp.name, 'EuregioCup 2019');
+
+      assert.strictEqual(this.store.peekRecord('strepla-competition', '123'), null);
+    });
+
+    test('throws a NotFoundError if the record does not exist', async function(assert) {
+      try {
+        await this.store.findRecord('strepla-competition', 123);
+        assert.fail('findRecord() unexpectedly did not fail');
+      } catch (error) {
+        assert.ok(error instanceof NotFoundError);
+        assert.equal(error.toString(), 'Error: Competition with ID 123 could not be found');
+        assert.equal(this.store.peekAll('strepla-competition').length, 0);
+      }
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server
+        .get('http://www.strepla.de/scs/ws/competition.ashx?cmd=active')
+        .intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.findRecord('strepla-competition', 577);
+        assert.fail('findRecord() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-competition: findRecord(577) failed');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competition').length, 0);
       }

--- a/tests/ember-data-strepla/strepla-competition-test.js
+++ b/tests/ember-data-strepla/strepla-competition-test.js
@@ -111,7 +111,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
         await this.store.query('strepla-competition', {});
         assert.fail('query() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-competition: query() failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competition').length, 0);
       }
@@ -168,7 +168,7 @@ module('ember-data-strepla | strepla-competition', function(hooks) {
         await this.store.findRecord('strepla-competition', 577);
         assert.fail('findRecord() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-competition: findRecord(577) failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competition').length, 0);
       }

--- a/tests/ember-data-strepla/strepla-competitor-test.js
+++ b/tests/ember-data-strepla/strepla-competitor-test.js
@@ -123,7 +123,7 @@ module('ember-data-strepla | strepla-competitor', function(hooks) {
         await this.store.query('strepla-competitor', { competitionId: 577 });
         assert.fail('query() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-competitor: query() failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-competitor').length, 0);
       }

--- a/tests/ember-data-strepla/strepla-competitor-test.js
+++ b/tests/ember-data-strepla/strepla-competitor-test.js
@@ -1,0 +1,139 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { COMPETITION_LIST_URL, COMPETITOR_LIST_URL } from 'ember-data-strepla/urls';
+
+import { setupQunit as setupPolly } from '@pollyjs/core';
+
+module('ember-data-strepla | strepla-competitor', function(hooks) {
+  setupTest(hooks);
+  setupPolly(hooks, { recordIfMissing: false });
+
+  hooks.beforeEach(function() {
+    this.server = this.polly.server;
+    this.store = this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.server.get(COMPETITOR_LIST_URL).intercept((req, res) => {
+      let classes = [];
+
+      if (req.query.cID === '577') {
+        classes.push(
+          {
+            id: 1,
+            name: 'Mustermann, Max',
+            country: 'LV Aachen',
+            glider_name: 'Duo Discus',
+            glider_callsign: 'D-9041',
+            glider_index: '110.00',
+            glider_cid: 'YD2',
+            flarm_ID: '',
+            logger1: '',
+            logger2: '',
+            logger3: '',
+            className: 'Hasen',
+          },
+          {
+            id: 2,
+            name: 'Bieniek, Tobias',
+            country: 'RSB Flugzeugpark n.e.V.',
+            glider_name: 'LS 6a',
+            glider_callsign: 'D-0816',
+            glider_index: '111.00',
+            glider_cid: 'SG',
+            flarm_ID: 'DD123456',
+            logger1: '6V7',
+            logger2: '42',
+            logger3: '',
+            className: 'Igel',
+          },
+          {
+            id: 3,
+            name: 'Doe, John',
+            country: 'FV Aachen',
+            glider_name: 'ASW 28-18',
+            glider_callsign: 'D-KWRL',
+            glider_index: '114.00',
+            glider_cid: '29',
+            flarm_ID: '',
+            logger1: '',
+            logger2: '',
+            logger3: '',
+            className: 'Hasen',
+          },
+        );
+      }
+
+      return res.status(200).send(classes);
+    });
+  });
+
+  module('query()', function() {
+    test('requests data from the API and transforms it to Ember Data models', async function(assert) {
+      let records = await this.store.query('strepla-competitor', { competitionId: 577 });
+
+      assert.equal(records.length, 3);
+
+      let record = records.objectAt(0);
+      assert.strictEqual(record.id, '577-1');
+      assert.equal(record.name, 'Mustermann, Max');
+
+      record = records.objectAt(1);
+      assert.strictEqual(record.id, '577-2');
+      assert.equal(record.name, 'Bieniek, Tobias');
+      assert.equal(record.type, 'LS 6a');
+      assert.equal(record.registration, 'D-0816');
+      assert.equal(record.callsign, 'SG');
+      assert.equal(record.handicap, 111);
+      assert.equal(record.flarmID, 'DD123456');
+      assert.equal(record.logger1, '6V7');
+      assert.equal(record.logger2, '42');
+      assert.equal(record.logger3, '');
+      assert.equal(record.className, 'Igel');
+
+      record = records.objectAt(2);
+      assert.strictEqual(record.id, '577-3');
+      assert.equal(record.name, 'Doe, John');
+    });
+
+    test('caches Ember Data models in the store', async function(assert) {
+      await this.store.query('strepla-competitor', { competitionId: 577 });
+      assert.equal(this.store.peekAll('strepla-competitor').length, 3);
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server.get(COMPETITOR_LIST_URL).intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.query('strepla-competitor', { competitionId: 577 });
+        assert.fail('query() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-competitor: query() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-competitor').length, 0);
+      }
+    });
+  });
+
+  test('has an async `competition` relationship', async function(assert) {
+    this.server.get(COMPETITION_LIST_URL).intercept((req, res) =>
+      res.status(200).send([
+        {
+          id: 577,
+          name: 'EuregioCup 2019',
+          Location: 'Aachen-Merzbrück',
+          firstDay: '2019-06-06T00:00:00',
+          lastDay: '2019-06-10T00:00:00',
+          fnLogo: '',
+        },
+      ]),
+    );
+
+    let records = await this.store.query('strepla-competitor', { competitionId: 577 });
+    let record = records.objectAt(0);
+
+    let competition = await record.competition;
+    assert.equal(competition.name, 'EuregioCup 2019');
+  });
+});

--- a/tests/ember-data-strepla/strepla-competitor-test.js
+++ b/tests/ember-data-strepla/strepla-competitor-test.js
@@ -97,6 +97,20 @@ module('ember-data-strepla | strepla-competitor', function(hooks) {
       assert.equal(record.name, 'Doe, John');
     });
 
+    test('accepts a `className` filter', async function(assert) {
+      let records = await this.store.query('strepla-competitor', { competitionId: 577, className: 'Hasen' });
+
+      assert.equal(records.length, 2);
+
+      let record = records.objectAt(0);
+      assert.strictEqual(record.id, '577-1');
+      assert.equal(record.name, 'Mustermann, Max');
+
+      record = records.objectAt(1);
+      assert.strictEqual(record.id, '577-3');
+      assert.equal(record.name, 'Doe, John');
+    });
+
     test('caches Ember Data models in the store', async function(assert) {
       await this.store.query('strepla-competitor', { competitionId: 577 });
       assert.equal(this.store.peekAll('strepla-competitor').length, 3);

--- a/tests/ember-data-strepla/strepla-task-test.js
+++ b/tests/ember-data-strepla/strepla-task-test.js
@@ -79,6 +79,7 @@ module('ember-data-strepla | strepla-task', function(hooks) {
       assert.equal(record.name, 'Tagesaufgabe A');
       assert.equal(record.distance, '361 km');
       assert.equal(record.ruleName, 'Racing-Task (RT)');
+      assert.strictEqual(record.minTime, null);
       assert.deepEqual(record.turnpoints, [
         {
           tp: {
@@ -119,6 +120,27 @@ module('ember-data-strepla | strepla-task', function(hooks) {
           },
         },
       ]);
+    });
+
+    test('can read AAT tasks too', async function(assert) {
+      this.server.get(TASK_URL).intercept((req, res) =>
+        res.status(200).send({
+          id: '7609',
+          name: 'Tagesaufgabe A',
+          distance: '190 km',
+          numLegs: '4',
+          rule: 'Speed Assigned Area Task (AAT)',
+          min_time: '02:15',
+          tps: [],
+        }),
+      );
+
+      let record = await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+
+      assert.ok(record);
+      assert.strictEqual(record.id, '7609');
+      assert.equal(record.ruleName, 'Speed Assigned Area Task (AAT)');
+      assert.strictEqual(record.minTime, 135);
     });
 
     test('caches the Ember Data model in the store', async function(assert) {

--- a/tests/ember-data-strepla/strepla-task-test.js
+++ b/tests/ember-data-strepla/strepla-task-test.js
@@ -1,0 +1,172 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { COMPETITION_LIST_URL, TASK_URL } from 'ember-data-strepla/urls';
+
+import { setupQunit as setupPolly } from '@pollyjs/core';
+
+module('ember-data-strepla | strepla-task', function(hooks) {
+  setupTest(hooks);
+  setupPolly(hooks, { recordIfMissing: false });
+
+  hooks.beforeEach(function() {
+    this.server = this.polly.server;
+    this.store = this.owner.lookup('service:store');
+  });
+
+  hooks.beforeEach(function() {
+    this.server.get(TASK_URL).intercept((req, res) => {
+      if (req.query.cID === '577' && req.query.idDay === '5917') {
+        return res.status(200).send({
+          id: '6553',
+          name: 'Tagesaufgabe A',
+          distance: '361 km',
+          numLegs: '4',
+          rule: 'Racing-Task (RT)',
+          tps: [
+            {
+              scoring: {
+                type: 'LINE',
+                width: 20000,
+              },
+              tp: {
+                id: '178687',
+                name: 'AP Zwickau West A72 BAB010',
+                lat: 50.6383333333333,
+                lng: 12.44,
+              },
+            },
+            {
+              scoring: {
+                type: 'KEYHOLE',
+                radiusCylinder: 500,
+                radiusSector: 10000,
+                angle: 90,
+              },
+              tp: {
+                id: '178900',
+                name: 'Marienberg Markt',
+                lat: 50.6508333333333,
+                lng: 13.1633333333333,
+              },
+            },
+            {
+              scoring: {
+                type: 'CYLINDER',
+                radius: 5000,
+              },
+              tp: {
+                id: '178672',
+                name: 'Zwickau FP EDBI',
+                lat: 50.7033333333333,
+                lng: 12.4591666666667,
+              },
+            },
+          ],
+        });
+      } else {
+        return res.status(500).send();
+      }
+    });
+  });
+
+  module('queryRecord()', function() {
+    test('requests data from the API and transforms it to an Ember Data model', async function(assert) {
+      let record = await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+
+      assert.ok(record);
+      assert.strictEqual(record.id, '6553');
+      assert.equal(record.name, 'Tagesaufgabe A');
+      assert.equal(record.distance, '361 km');
+      assert.equal(record.ruleName, 'Racing-Task (RT)');
+      assert.deepEqual(record.turnpoints, [
+        {
+          tp: {
+            id: '178687',
+            name: 'AP Zwickau West A72 BAB010',
+            lat: 50.6383333333333,
+            lng: 12.44,
+          },
+          scoring: {
+            type: 'LINE',
+            width: 20000,
+          },
+        },
+        {
+          tp: {
+            id: '178900',
+            name: 'Marienberg Markt',
+            lat: 50.6508333333333,
+            lng: 13.1633333333333,
+          },
+          scoring: {
+            type: 'KEYHOLE',
+            angle: 90,
+            radiusCylinder: 500,
+            radiusSector: 10000,
+          },
+        },
+        {
+          tp: {
+            id: '178672',
+            name: 'Zwickau FP EDBI',
+            lat: 50.7033333333333,
+            lng: 12.4591666666667,
+          },
+          scoring: {
+            type: 'CYLINDER',
+            radius: 5000,
+          },
+        },
+      ]);
+    });
+
+    test('caches the Ember Data model in the store', async function(assert) {
+      await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+      assert.equal(this.store.peekAll('strepla-task').length, 1);
+    });
+
+    test('throws an error if the server responds with an error', async function(assert) {
+      this.server.get(TASK_URL).intercept((req, res) => res.status(500).send());
+
+      try {
+        await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+        assert.fail('queryRecord() unexpectedly did not fail');
+      } catch (error) {
+        assert.equal(error.toString(), 'Error: strepla-task: queryRecord() failed');
+        assert.equal(error.response.status, 500);
+        assert.equal(this.store.peekAll('strepla-task').length, 0);
+      }
+    });
+  });
+
+  test('has an async `competition` relationship', async function(assert) {
+    this.server.get(COMPETITION_LIST_URL).intercept((req, res) =>
+      res.status(200).send([
+        {
+          id: 577,
+          name: 'EuregioCup 2019',
+          Location: 'Aachen-Merzbrück',
+          firstDay: '2019-06-06T00:00:00',
+          lastDay: '2019-06-10T00:00:00',
+          fnLogo: '',
+        },
+      ]),
+    );
+
+    let record = await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+
+    let competition = await record.competition;
+    assert.equal(competition.name, 'EuregioCup 2019');
+  });
+
+  test('has an async `competitionDay` relationship', async function(assert) {
+    let record = await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
+
+    // `await record.competitionDay` does not work because `findRecord()` is not
+    // implemented for the `strepla-competition-day` adapter, but at least we
+    // can access the ID of the related record
+
+    assert.equal(record.belongsTo('competitionDay').id(), '5917');
+  });
+});

--- a/tests/ember-data-strepla/strepla-task-test.js
+++ b/tests/ember-data-strepla/strepla-task-test.js
@@ -120,6 +120,9 @@ module('ember-data-strepla | strepla-task', function(hooks) {
           },
         },
       ]);
+
+      assert.ok(record.isRacing);
+      assert.notOk(record.isAAT);
     });
 
     test('can read AAT tasks too', async function(assert) {
@@ -141,6 +144,9 @@ module('ember-data-strepla | strepla-task', function(hooks) {
       assert.strictEqual(record.id, '7609');
       assert.equal(record.ruleName, 'Speed Assigned Area Task (AAT)');
       assert.strictEqual(record.minTime, 135);
+
+      assert.notOk(record.isRacing);
+      assert.ok(record.isAAT);
     });
 
     test('caches the Ember Data model in the store', async function(assert) {

--- a/tests/ember-data-strepla/strepla-task-test.js
+++ b/tests/ember-data-strepla/strepla-task-test.js
@@ -133,7 +133,7 @@ module('ember-data-strepla | strepla-task', function(hooks) {
         await this.store.queryRecord('strepla-task', { competitionId: 577, competitionDayId: 5917 });
         assert.fail('queryRecord() unexpectedly did not fail');
       } catch (error) {
-        assert.equal(error.toString(), 'Error: strepla-task: queryRecord() failed');
+        assert.equal(error.toString(), 'Error: The adapter operation failed due to a server error');
         assert.equal(error.response.status, 500);
         assert.equal(this.store.peekAll('strepla-task').length, 0);
       }

--- a/tests/ember-data-strepla/transforms/strepla-date-test.js
+++ b/tests/ember-data-strepla/transforms/strepla-date-test.js
@@ -1,5 +1,5 @@
-import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
 module('ember-data-strepla | Transforms | strepla-date', function(hooks) {
   setupTest(hooks);
@@ -30,7 +30,7 @@ module('ember-data-strepla | Transforms | strepla-date', function(hooks) {
   });
 
   module('serialize()', function() {
-    test('is not available', function (assert) {
+    test('is not available', function(assert) {
       assert.strictEqual(this.transform.serialize, null);
     });
   });

--- a/tests/ember-data-strepla/transforms/strepla-date-test.js
+++ b/tests/ember-data-strepla/transforms/strepla-date-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('ember-data-strepla | Transforms | strepla-date', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.transform = this.owner.lookup('transform:strepla-date');
+  });
+
+  module('deserialize()', function() {
+    test('deserializes ISO date strings from the StrePla API', function(assert) {
+      let result = this.transform.deserialize('2019-06-06T00:00:00');
+
+      assert.equal(typeof result, 'object');
+      assert.equal(result.constructor.name, 'Date');
+
+      assert.equal(result.getFullYear(), 2019);
+      assert.equal(result.getMonth(), 5);
+      assert.equal(result.getDate(), 6);
+      assert.equal(result.getHours(), 0);
+      assert.equal(result.getMinutes(), 0);
+      assert.equal(result.getSeconds(), 0);
+      assert.equal(result.getMilliseconds(), 0);
+    });
+
+    test('throws errors for invalid dates', function(assert) {
+      assert.throws(() => this.transform.deserialize('ff'), /Invalid date: ff/);
+    });
+  });
+
+  module('serialize()', function() {
+    test('is not available', function (assert) {
+      assert.strictEqual(this.transform.serialize, null);
+    });
+  });
+});

--- a/tests/ember-data-strepla/transforms/strepla-duration-test.js
+++ b/tests/ember-data-strepla/transforms/strepla-duration-test.js
@@ -1,0 +1,44 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('ember-data-strepla | Transforms | strepla-duration', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.transform = this.owner.lookup('transform:strepla-duration');
+  });
+
+  module('deserialize()', function() {
+    test('deserializes valid durations', function(assert) {
+      assert.strictEqual(this.transform.deserialize('0:00'), 0);
+      assert.strictEqual(this.transform.deserialize('00:00'), 0);
+      assert.strictEqual(this.transform.deserialize('00:01'), 1);
+      assert.strictEqual(this.transform.deserialize('00:42'), 42);
+      assert.strictEqual(this.transform.deserialize('00:59'), 59);
+      assert.strictEqual(this.transform.deserialize('01:00'), 60);
+      assert.strictEqual(this.transform.deserialize('01:23'), 83);
+      assert.strictEqual(this.transform.deserialize('12:34'), 754);
+      assert.strictEqual(this.transform.deserialize('4:32'), 272);
+    });
+
+    test('deserializes empty values to `null`', function(assert) {
+      assert.strictEqual(this.transform.deserialize(), null);
+      assert.strictEqual(this.transform.deserialize(undefined), null);
+      assert.strictEqual(this.transform.deserialize(null), null);
+      assert.strictEqual(this.transform.deserialize(''), null);
+    });
+
+    test('throws errors for invalid durations', function(assert) {
+      assert.throws(() => this.transform.deserialize(123), /Invalid duration: 123/);
+      assert.throws(() => this.transform.deserialize({}), /Invalid duration: .+/);
+      assert.throws(() => this.transform.deserialize('ff'), /Invalid duration: ff/);
+      assert.throws(() => this.transform.deserialize('00:60'), /Invalid duration: 00:60/);
+    });
+  });
+
+  module('serialize()', function() {
+    test('is not available', function(assert) {
+      assert.strictEqual(this.transform.serialize, null);
+    });
+  });
+});

--- a/tests/utils/strepla-to-xcsoar-test.js
+++ b/tests/utils/strepla-to-xcsoar-test.js
@@ -1,0 +1,172 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { convertTask } from 'ogn-web-viewer/utils/strepla-to-xcsoar';
+
+module('Utils | strepla-to-xcsoar | convertTask', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(async function() {
+    let { readTaskFromString } = await import('aeroscore/dist/src/read-task');
+    this.readTaskFromString = readTaskFromString;
+  });
+
+  test('can convert a racing task', function(assert) {
+    let taskRecord = this.owner.lookup('service:store').createRecord('strepla-task');
+
+    taskRecord.setProperties({
+      ruleName: 'Racing-Task (RT)',
+      turnpoints: [
+        {
+          tp: {
+            id: '178687',
+            name: 'AP Zwickau West A72 BAB010',
+            lat: 50.6383333333333,
+            lng: 12.44,
+          },
+          scoring: {
+            type: 'LINE',
+            width: 20000,
+          },
+        },
+        {
+          tp: {
+            id: '178900',
+            name: 'Marienberg Markt',
+            lat: 50.6508333333333,
+            lng: 13.1633333333333,
+          },
+          scoring: {
+            type: 'KEYHOLE',
+            angle: 90,
+            radiusCylinder: 500,
+            radiusSector: 10000,
+          },
+        },
+        {
+          tp: {
+            id: '178672',
+            name: 'Zwickau FP EDBI',
+            lat: 50.7033333333333,
+            lng: 12.4591666666667,
+          },
+          scoring: {
+            type: 'CYLINDER',
+            radius: 5000,
+          },
+        },
+      ],
+    });
+
+    let result = convertTask(taskRecord);
+
+    assert.equal(
+      result,
+      [
+        '<Task type="RT">',
+        '  <Point type="Start">',
+        '    <Waypoint id="178687" name="AP Zwickau West A72 BAB010">',
+        '      <Location latitude="50.6383333333333" longitude="12.44"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Line" length="20000"/>',
+        '  </Point>',
+        '  <Point type="Turn">',
+        '    <Waypoint id="178900" name="Marienberg Markt">',
+        '      <Location latitude="50.6508333333333" longitude="13.1633333333333"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Keyhole"/>',
+        '  </Point>',
+        '  <Point type="Finish">',
+        '    <Waypoint id="178672" name="Zwickau FP EDBI">',
+        '      <Location latitude="50.7033333333333" longitude="12.4591666666667"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Cylinder" radius="5000"/>',
+        '  </Point>',
+        '</Task>',
+      ].join('\n'),
+    );
+
+    let task = this.readTaskFromString(result);
+    assert.ok(task);
+  });
+
+  test('can convert an area task', function(assert) {
+    let taskRecord = this.owner.lookup('service:store').createRecord('strepla-task');
+
+    taskRecord.setProperties({
+      ruleName: 'Speed Assigned Area Task (AAT)',
+      minTime: 192,
+      turnpoints: [
+        {
+          tp: {
+            id: '178687',
+            name: 'AP Zwickau West A72 BAB010',
+            lat: 50.6383333333333,
+            lng: 12.44,
+          },
+          scoring: {
+            type: 'LINE',
+            width: 20000,
+          },
+        },
+        {
+          tp: {
+            id: '178900',
+            name: 'Marienberg Markt',
+            lat: 50.6508333333333,
+            lng: 13.1633333333333,
+          },
+          scoring: {
+            type: 'AAT SECTOR',
+            radius: 10000,
+            radial1: 0,
+            radial2: 0,
+          },
+        },
+        {
+          tp: {
+            id: '178672',
+            name: 'Zwickau FP EDBI',
+            lat: 50.7033333333333,
+            lng: 12.4591666666667,
+          },
+          scoring: {
+            type: 'CYLINDER',
+            radius: 5000,
+          },
+        },
+      ],
+    });
+
+    let result = convertTask(taskRecord);
+
+    assert.equal(
+      result,
+      [
+        '<Task aat_min_time="192" type="AAT">',
+        '  <Point type="Start">',
+        '    <Waypoint id="178687" name="AP Zwickau West A72 BAB010">',
+        '      <Location latitude="50.6383333333333" longitude="12.44"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Line" length="20000"/>',
+        '  </Point>',
+        '  <Point type="Turn">',
+        '    <Waypoint id="178900" name="Marienberg Markt">',
+        '      <Location latitude="50.6508333333333" longitude="13.1633333333333"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Cylinder" radius="10000"/>',
+        '  </Point>',
+        '  <Point type="Finish">',
+        '    <Waypoint id="178672" name="Zwickau FP EDBI">',
+        '      <Location latitude="50.7033333333333" longitude="12.4591666666667"/>',
+        '    </Waypoint>',
+        '    <ObservationZone type="Cylinder" radius="5000"/>',
+        '  </Point>',
+        '</Task>',
+      ].join('\n'),
+    );
+
+    let task = this.readTaskFromString(result);
+    assert.ok(task);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,7 +726,25 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.2", "@babel/types@^7.3.4", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.0":
+"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
+  integrity sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.1.5", "@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.3.0", "@babel/types@^7.3.2", "@babel/types@^7.3.4", "@babel/types@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.0.tgz#e47d43840c2e7f9105bc4d3a2c371b4d0c7832ab"
   integrity sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==
@@ -806,6 +824,14 @@
     silent-error "^1.1.0"
     util.promisify "^1.0.0"
 
+"@ember/ordered-set@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@ember/ordered-set/-/ordered-set-2.0.3.tgz#2ac1ca73b3bd116063cae814898832ef434a57f9"
+  integrity sha512-F4yfVk6WMc4AUHxeZsC3CaKyTvO0qSZJy7WWHCFTlVDQw6vubn+FvnGdhzpN1F00EiXMI4Tv1tJdSquHcCnYrA==
+  dependencies:
+    ember-cli-babel "^6.16.0"
+    ember-compatibility-helpers "^1.1.1"
+
 "@ember/test-helpers@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.5.0.tgz#a480181c412778294e317c256d04ca52e63c813a"
@@ -877,6 +903,11 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.1.tgz#5286b6b32040232b751138f6d006130c728d4b3d"
   integrity sha512-0D53YVuEgGdHfTl9LGWDZqVzGhn4cT0CXqyAuOYkKFLvqboJXz6SnkRhQNPhhA2hLVrPnvUz3+choQmPhHLGGQ==
+
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
 "@glimmer/interfaces@^0.41.0":
   version "0.41.0"
@@ -2658,6 +2689,19 @@ babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-p
   dependencies:
     ember-rfc176-data "^0.3.9"
 
+babel-plugin-feature-flags@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz#9c827cf9a4eb9a19f725ccb239e85cab02036fc1"
+  integrity sha1-nIJ8+aTrmhn3JcyyOehcqwIDb8E=
+
+babel-plugin-filter-imports@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-2.0.4.tgz#9209b708ed3b228349c4e6f660358bf02685e803"
+  integrity sha512-Ra4VylqMFsmTJCUeLRJ/OP2ZqO0cCJQK2HKihNTnoKP4f8IhxHKL4EkbmfkwGjXCeDyXd0xQ6UTK8Nd+h9V/SQ==
+  dependencies:
+    "@babel/types" "^7.1.5"
+    lodash "^4.17.11"
+
 babel-plugin-htmlbars-inline-precompile@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
@@ -3042,6 +3086,16 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babel6-plugin-strip-class-callcheck@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
+  integrity sha1-3oQcGr6705943gr/ssmlLuIo/d8=
+
+babel6-plugin-strip-heimdall@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-heimdall/-/babel6-plugin-strip-heimdall-6.0.1.tgz#35f80eddec1f7fffdc009811dfbd46d9965072b6"
+  integrity sha1-NfgO3ewff//cAJgR371G2ZZQcrY=
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -3460,6 +3514,14 @@ broccoli-favicon@~2.1.1:
     himalaya "1.1.0"
     lodash.merge "~4.6.1"
 
+broccoli-file-creator@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
+  integrity sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
@@ -3654,7 +3716,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0, broccoli-plugin@^1.3.1:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0, broccoli-plugin@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
@@ -4098,6 +4160,13 @@ calculate-cache-key-for-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
   integrity sha1-DD5CycE088neU1jA8WeTYn6pdtY=
+  dependencies:
+    json-stable-stringify "^1.0.1"
+
+calculate-cache-key-for-tree@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.2.3.tgz#5a5e4fcfa2d374a63e47fe967593f179e8282825"
+  integrity sha512-PPQorvdNw8K8k7UftCeradwOmKDSDJs8wcqYTtJPEt3fHbZyK8QsorybJA+lOmk0dgE61vX6R+5Kd3W9h4EMGg==
   dependencies:
     json-stable-stringify "^1.0.1"
 
@@ -5606,10 +5675,17 @@ ember-cli-sri@^2.1.1:
   dependencies:
     broccoli-sri-hash "^2.1.0"
 
-ember-cli-string-utils@^1.1.0:
+ember-cli-string-utils@^1.0.0, ember-cli-string-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz#39b677fc2805f55173735376fcef278eaa4452a1"
   integrity sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=
+
+ember-cli-test-info@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz#ed4e960f249e97523cf891e4aed2072ce84577b4"
+  integrity sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=
+  dependencies:
+    ember-cli-string-utils "^1.0.0"
 
 ember-cli-test-loader@^2.2.0:
   version "2.2.0"
@@ -5618,7 +5694,7 @@ ember-cli-test-loader@^2.2.0:
   dependencies:
     ember-cli-babel "^6.8.1"
 
-ember-cli-typescript@^2.0.1:
+ember-cli-typescript@^2.0.0, ember-cli-typescript@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-2.0.1.tgz#9c46729213b9e1d13f5c3ff8421d772134aa889e"
   integrity sha512-xwSEQOUNM621Wt+XJWpbLhBIeqC/dM1lDS+oZQ2nSjxp4MLZkpKuiVBqdbBWcURbvv8ghoVQPfy8wYU4JIFkLA==
@@ -5764,7 +5840,7 @@ ember-cli@~3.10.1:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.2.0:
+ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
@@ -5813,6 +5889,39 @@ ember-css-modules@^1.2.1:
     semver "^5.5.0"
     toposort "^1.0.6"
 
+ember-data@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.9.1.tgz#ba9de5ffee05c0bcf061237b2d53b9a0258dfb2c"
+  integrity sha512-qSyAMFiGwzrOvrR59HSVOFu5SYZRWyA6M0Utwi11lQzrG27/+na9317MQ56k71xKwisR5bvPO7HuYVl0iWzDeA==
+  dependencies:
+    "@ember/ordered-set" "^2.0.3"
+    "@glimmer/env" "^0.1.7"
+    babel-plugin-feature-flags "^0.3.1"
+    babel-plugin-filter-imports "^2.0.4"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    babel6-plugin-strip-heimdall "^6.0.1"
+    broccoli-debug "^0.6.5"
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-rollup "^2.1.1"
+    calculate-cache-key-for-tree "^1.2.0"
+    chalk "^2.4.1"
+    ember-cli-babel "^7.7.3"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-test-info "^1.0.0"
+    ember-cli-typescript "^2.0.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-fetch "^6.5.0"
+    ember-inflector "^3.0.0"
+    git-repo-info "^2.0.0"
+    heimdalljs "^0.3.0"
+    inflection "^1.12.0"
+    npm-git-info "^1.0.3"
+    resolve "^1.8.1"
+    silent-error "^1.1.1"
+
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -5825,7 +5934,7 @@ ember-factory-for-polyfill@^1.3.1:
   dependencies:
     ember-cli-version-checker "^2.1.0"
 
-ember-fetch@^6.7.0:
+ember-fetch@^6.5.0, ember-fetch@^6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-6.7.0.tgz#c219f820e40f7918147391617a5940c67d293319"
   integrity sha512-lB9G+XDKOc84Dr3THJs+l/KmtzUus7nv12Z0xOP54J917HmjnAsSZ9OHTp+X8ClxlAm35/v9l+sFd7IlB9Baqw==
@@ -5864,6 +5973,13 @@ ember-getowner-polyfill@^2.0.1:
   dependencies:
     ember-cli-version-checker "^2.1.0"
     ember-factory-for-polyfill "^1.3.1"
+
+ember-inflector@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.0.tgz#7e1ee8aaa0fa773ba0905d8b7c0786354d890ee1"
+  integrity sha512-tLWfYolZAkLnkTvvBkjizy4Wmj8yI8wqHZFK+leh0iScHiC3r1Yh5C4qO+OMGiBTMLwfTy+YqVoE/Nu3hGNkcA==
+  dependencies:
+    ember-cli-babel "^6.6.0"
 
 ember-intl@^4.0.1:
   version "4.0.1"
@@ -7318,7 +7434,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-repo-info@^2.1.0:
+git-repo-info@^2.0.0, git-repo-info@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-2.1.0.tgz#13d1f753c75bc2994432e65a71e35377ff563813"
   integrity sha512-+kigfDB7j3W80f74BoOUX+lKOmf4pR3/i2Ww6baKTCPe2hD4FRdjhV3s4P5Dy0Tak1uY1891QhKoYNtnyX2VvA==
@@ -7673,6 +7789,13 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.6.tgz#b0eebabc412813aeb9542f9cc622cb58dbdcd9fe"
   integrity sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==
+  dependencies:
+    rsvp "~3.2.1"
+
+heimdalljs@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
+  integrity sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=
   dependencies:
     rsvp "~3.2.1"
 
@@ -10721,6 +10844,11 @@ npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
   integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
+
+npm-git-info@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"
+  integrity sha1-qTPELsMh6A02RuDW6ESv6UYw4dU=
 
 npm-package-arg@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
This PR resolves https://github.com/Turbo87/ogn-web-viewer/issues/79 by adding basic support for scoring*StrePla via `/strepla/<competitionID>/<class>/<date>` routes.