### PR TITLE
Use Ember Octane edition

### DIFF
--- a/.ember-cli.js
+++ b/.ember-cli.js
@@ -1,9 +1,15 @@
-{
+'use strict';
+
+const { setEdition } = require('@ember/edition-utils');
+
+setEdition('octane');
+
+module.exports = {
   /**
     Ember CLI sends analytics information by default. The data is completely
     anonymous, but there are times when you might want to disable this behavior.
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
-}
+  disableAnalytics: false,
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ module.exports = {
     // node files
     {
       files: [
+        '.ember-cli.js',
         '.eslintrc.js',
         '.prettierrc.js',
         '.template-lintrc.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,7 +74,7 @@ module.exports = {
           // Testing modules
           ['/^qunit/', '/^ember-qunit/', '/^@ember/test-helpers/', '/^ember-exam/'],
           // Ember.js modules
-          ['/^ember$/', '/^@ember/', '/^ember-data/'],
+          ['/^ember$/', '/^@ember/', '/^ember-data/', '/^@glimmer//'],
           ['module'],
           [`/^${require('./package.json').name}\\//`],
           ['parent', 'sibling', 'index'],

--- a/app/components/aircraft-layer.js
+++ b/app/components/aircraft-layer.js
@@ -1,6 +1,6 @@
-import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 
 import VectorLayer from 'ol/layer/Vector';
 import { Icon, Stroke, Style, Text } from 'ol/style';
@@ -14,8 +14,6 @@ export default class extends Component {
   @service filter;
   @service('map') mapService;
 
-  tagName = '';
-
   @alias('mapService.map') map;
 
   _iconStyles = new WeakMap();
@@ -26,14 +24,14 @@ export default class extends Component {
     style: (...args) => this._getFeatureStyle(...args),
   });
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
+  constructor() {
+    super(...arguments);
     this.map.addLayer(this.layer);
   }
 
-  willDestroyElement() {
+  willDestroy() {
     this.map.removeLayer(this.layer);
-    super.willDestroyElement(...arguments);
+    super.willDestroy();
   }
 
   _getFeatureStyle(feature, resolution) {

--- a/app/components/aircraft-shadow-layer.js
+++ b/app/components/aircraft-shadow-layer.js
@@ -1,6 +1,6 @@
-import Component from '@ember/component';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 
 import VectorLayer from 'ol/layer/Vector';
 import { Icon, Style } from 'ol/style';
@@ -13,8 +13,6 @@ export default class extends Component {
   @service filter;
   @service('map') mapService;
 
-  tagName = '';
-
   @alias('mapService.map') map;
 
   _iconStyles = new WeakMap();
@@ -26,14 +24,14 @@ export default class extends Component {
     style: (...args) => this._getFeatureStyle(...args),
   });
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
+  constructor() {
+    super(...arguments);
     this.map.addLayer(this.layer);
   }
 
-  willDestroyElement() {
+  willDestroy() {
     this.map.removeLayer(this.layer);
-    super.willDestroyElement(...arguments);
+    super.willDestroy();
   }
 
   _getFeatureStyle(feature) {

--- a/app/components/fullscreen-button.js
+++ b/app/components/fullscreen-button.js
@@ -1,20 +1,18 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 import { FullScreen } from 'ol/control';
 
 export default class extends Component {
-  tagName = '';
-
   map = null;
   control = new FullScreen();
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-    this.map.addControl(this.control);
+  constructor() {
+    super(...arguments);
+    this.args.map.addControl(this.control);
   }
 
-  willDestroyElement() {
-    this.map.removeControl(this.control);
-    super.willDestroyElement(...arguments);
+  willDestroy() {
+    this.args.map.removeControl(this.control);
+    super.willDestroy();
   }
 }

--- a/app/components/map.js
+++ b/app/components/map.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
@@ -28,15 +29,11 @@ export default class extends Component {
       }
     });
 
-    this.map.setTarget('map');
-
     this.ws.on('record', this, 'handleRecord');
   }
 
   willDestroyElement() {
     this.ws.off('record', this, 'handleRecord');
-
-    this.map.setTarget(null);
 
     super.willDestroyElement(...arguments);
   }
@@ -57,5 +54,10 @@ export default class extends Component {
   getBBox() {
     let extent = this.map.getView().calculateExtent();
     return transformExtent(extent, EPSG_3857, EPSG_4326);
+  }
+
+  @action
+  setMapTarget(element) {
+    this.map.setTarget(element);
   }
 }

--- a/app/components/map.js
+++ b/app/components/map.js
@@ -1,7 +1,7 @@
-import Component from '@ember/component';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 
 import { transformExtent } from 'ol/proj';
 
@@ -15,13 +15,11 @@ export default class extends Component {
   @service ws;
   @service('map') mapService;
 
-  tagName = '';
-
   @alias('filter.hasFilter') hasDeviceFilter;
   @alias('mapService.map') map;
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
+  constructor() {
+    super(...arguments);
 
     this.map.on('moveend', () => {
       if (!this.filter.hasFilter) {
@@ -32,10 +30,10 @@ export default class extends Component {
     this.ws.on('record', this, 'handleRecord');
   }
 
-  willDestroyElement() {
+  willDestroy() {
     this.ws.off('record', this, 'handleRecord');
 
-    super.willDestroyElement(...arguments);
+    super.willDestroy(...arguments);
   }
 
   handleRecord(record) {

--- a/app/components/score-table.js
+++ b/app/components/score-table.js
@@ -1,6 +1,7 @@
-import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 
 import * as Sentry from '@sentry/browser';
@@ -21,11 +22,9 @@ export default class extends Component {
   @service filter;
   @service history;
 
-  tagName = '';
-
   dayFactors = null;
   results = [];
-  rows = [];
+  @tracked rows = [];
 
   @computed('filter.filter')
   get initialDayFactors() {
@@ -56,7 +55,9 @@ export default class extends Component {
     let results = this.filter.filter.map(filterRow => {
       let fixes = this.history.forId(filterRow.id);
 
-      let solver = this.task.options.isAAT ? new AreaTaskSolver(this.task) : new RacingTaskSolver(this.task);
+      let solver = this.args.task.options.isAAT
+        ? new AreaTaskSolver(this.args.task)
+        : new RacingTaskSolver(this.args.task);
 
       let dayResult, landed, startTimestamp, altitude;
       try {
@@ -76,9 +77,9 @@ export default class extends Component {
         let H = filterRow.handicap / 100;
 
         dayResult =
-          landed || result.completed || this.task.options.isAAT
+          landed || result.completed || this.args.task.options.isAAT
             ? createInitialDayResult(result, this.initialDayFactors, H)
-            : createIntermediateDayResult(result, this.initialDayFactors, H, this.task, Date.now() / 1000);
+            : createIntermediateDayResult(result, this.initialDayFactors, H, this.args.task, Date.now() / 1000);
       } catch (error) {
         Sentry.captureException(error);
 
@@ -95,28 +96,25 @@ export default class extends Component {
       return { ...dayResult, landed, filterRow, startTimestamp, altitude };
     });
 
-    this.set('dayFactors', calculateDayFactors(results, this.initialDayFactors));
+    this.dayFactors = calculateDayFactors(results, this.initialDayFactors);
 
-    this.set('results', results.map(result => calculateDayResult(result, this.dayFactors)).sort(compareDayResults));
+    this.results = results.map(result => calculateDayResult(result, this.dayFactors)).sort(compareDayResults);
 
-    this.set(
-      'rows',
-      this.results.map((result, i) => {
-        let { filterRow } = result;
+    this.rows = this.results.map((result, i) => {
+      let { filterRow } = result;
 
-        return {
-          num: `${result.landed || result._completed ? ' ' : '!'} ${i + 1}`,
-          cn: filterRow.callsign,
-          name: filterRow.name,
-          type: filterRow.type,
-          startTime: result.startTimestamp ? formatTime(result.startTimestamp) : '',
-          time: result._T ? formatDuration(result._T) : '',
-          distance: result._D ? `${result._D.toFixed(1)} km` : '',
-          speed: result._V ? `${result._V.toFixed(2)} km/h` : '',
-          score: result.S,
-          altitude: result.altitude !== null ? `${Math.round(result.altitude)} m` : '',
-        };
-      }),
-    );
+      return {
+        num: `${result.landed || result._completed ? ' ' : '!'} ${i + 1}`,
+        cn: filterRow.callsign,
+        name: filterRow.name,
+        type: filterRow.type,
+        startTime: result.startTimestamp ? formatTime(result.startTimestamp) : '',
+        time: result._T ? formatDuration(result._T) : '',
+        distance: result._D ? `${result._D.toFixed(1)} km` : '',
+        speed: result._V ? `${result._V.toFixed(2)} km/h` : '',
+        score: result.S,
+        altitude: result.altitude !== null ? `${Math.round(result.altitude)} m` : '',
+      };
+    });
   }
 }

--- a/app/components/score-table.js
+++ b/app/components/score-table.js
@@ -44,16 +44,6 @@ export default class extends Component {
     };
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-    this.updateTask.perform();
-  }
-
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
-    this.updateTask.cancelAll();
-  }
-
   @task
   updateTask = function*() {
     while (!Ember.testing) {

--- a/app/components/task-layer.js
+++ b/app/components/task-layer.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
@@ -59,31 +59,28 @@ export default class extends Component {
     return taskSource;
   }
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
+  constructor() {
+    super(...arguments);
 
-    this.set(
-      'layer',
-      new VectorLayer({
-        id: 'task',
-        source: this.source,
-        style(feature) {
-          let id = feature.getId();
-          return id === 'legs' ? TASK_LEGS_STYLE : TASK_AREA_STYLE;
-        },
-      }),
-    );
+    this.layer = new VectorLayer({
+      id: 'task',
+      source: this.source,
+      style(feature) {
+        let id = feature.getId();
+        return id === 'legs' ? TASK_LEGS_STYLE : TASK_AREA_STYLE;
+      },
+    });
 
     this.map.addLayer(this.layer);
   }
 
-  didUpdateAttrs() {
-    super.didUpdateAttrs(...arguments);
-    this.layer.setSource(this.source);
+  willDestroy() {
+    this.map.removeLayer(this.layer);
+    super.willDestroy(...arguments);
   }
 
-  willDestroyElement() {
-    this.map.removeLayer(this.layer);
-    super.willDestroyElement(...arguments);
+  @action
+  updateSource() {
+    this.layer.setSource(this.source);
   }
 }

--- a/app/components/task-layer.js
+++ b/app/components/task-layer.js
@@ -1,7 +1,7 @@
-import Component from '@ember/component';
 import { computed, action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 
 import { Feature } from 'ol';
 import { LineString } from 'ol/geom';
@@ -35,24 +35,20 @@ const TASK_AREA_STYLE = new Style({
 export default class extends Component {
   @service('map') mapService;
 
-  tagName = '';
-
-  task = null;
-
   @alias('mapService.map') map;
 
-  @computed('task')
+  @computed('args.task')
   get source() {
     let taskSource = new VectorSource({ features: [] });
 
-    if (this.task) {
+    if (this.args.task) {
       let legsFeature = new Feature({
-        geometry: new LineString(this.task.points.map(pt => transform(pt.shape.center, EPSG_4326, EPSG_3857))),
+        geometry: new LineString(this.args.task.points.map(pt => transform(pt.shape.center, EPSG_4326, EPSG_3857))),
       });
       legsFeature.setId('legs');
       taskSource.addFeature(legsFeature);
 
-      let areas = this.task.points.map(pt => GeoJSON.readFeature(pt.shape.toGeoJSON()));
+      let areas = this.args.task.points.map(pt => GeoJSON.readFeature(pt.shape.toGeoJSON()));
       taskSource.addFeatures(areas);
     }
 
@@ -76,7 +72,7 @@ export default class extends Component {
 
   willDestroy() {
     this.map.removeLayer(this.layer);
-    super.willDestroy(...arguments);
+    super.willDestroy();
   }
 
   @action

--- a/app/components/zoom-buttons.js
+++ b/app/components/zoom-buttons.js
@@ -1,20 +1,18 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 import Zoom from 'ol/control/Zoom';
 
 export default class extends Component {
-  tagName = '';
-
   map = null;
   control = new Zoom();
 
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-    this.map.addControl(this.control);
+  constructor() {
+    super(...arguments);
+    this.args.map.addControl(this.control);
   }
 
-  willDestroyElement() {
-    this.map.removeControl(this.control);
-    super.willDestroyElement(...arguments);
+  willDestroy() {
+    this.args.map.removeControl(this.control);
+    super.willDestroy(...arguments);
   }
 }

--- a/app/helpers/call-on-update.js
+++ b/app/helpers/call-on-update.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * This helper is roughly similar to the `did-update` render modifier, but
+ * does not require an element to run it on. This means it can also be used
+ * in situations where the component has no template contents, such as the
+ * layer components in this project.
+ */
+export default helper(function callOnUpdate(params) {
+  params[0]();
+});

--- a/app/templates/components/map.hbs
+++ b/app/templates/components/map.hbs
@@ -1,4 +1,10 @@
-<div id="map" style="width: 100%; height: {{if (and hasDeviceFilter @task) "70%" "100%"}}" data-test-map>
+<div
+  id="map"
+  style="width: 100%; height: {{if (and hasDeviceFilter @task) "70%" "100%"}}"
+  data-test-map
+  {{did-insert this.setMapTarget}}
+  {{will-destroy (fn this.setMapTarget null)}}
+>
   <TaskLayer @task={{@task}}/>
 
   <AircraftShadowLayer/>

--- a/app/templates/components/score-table.hbs
+++ b/app/templates/components/score-table.hbs
@@ -1,4 +1,4 @@
-<table local-class="score-table" data-test-scores>
+<table local-class="score-table" data-test-scores {{did-insert (perform updateTask)}}>
   <thead>
     <tr>
       <th></th>

--- a/app/templates/components/task-layer.hbs
+++ b/app/templates/components/task-layer.hbs
@@ -1,0 +1,1 @@
+{{call-on-update this.updateSource @task}}

--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,5 +1,6 @@
 {
   "application-template-wrapper": false,
+  "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "sockette": "^2.0.6"
   },
   "devDependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
     "@pollyjs/ember": "^2.6.2",
     "babel-eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
+    "@glimmer/component": "^0.14.0-alpha.13",
     "@pollyjs/ember": "^2.6.2",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^1.0.0",
+    "@ember/render-modifiers": "^1.0.1",
     "@glimmer/component": "^0.14.0-alpha.13",
     "@pollyjs/ember": "^2.6.2",
     "babel-eslint": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,14 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
+"@ember/render-modifiers@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.1.tgz#a85e746e4bb9fd51302cc43e726e2c641261a7c2"
+  integrity sha512-HHZwL84jCVAaIDFtPZHAnM41aB8XgvDiutD1tKnll43fw7/rhejGj/LDWdB1jrPF+vryFSSQwSJ85gk4J7W86g==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+
 "@ember/test-helpers@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.6.0.tgz#e928c0190a19c312bf40dc8a6f4159735af48a7f"
@@ -6051,6 +6059,15 @@ ember-maybe-import-regenerator@^0.1.6:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
+
+ember-modifier-manager-polyfill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
+  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
 
 ember-page-title@^5.1.0:
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,20 +1063,81 @@
     "@glimmer/util" "^0.42.0"
     "@glimmer/wire-format" "^0.42.0"
 
+"@glimmer/component@^0.14.0-alpha.13":
+  version "0.14.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-0.14.0-alpha.13.tgz#5e1912bee8a00504e8ea20cc59600956a9c435ee"
+  integrity sha512-dYXfMwIyOUi0XEYJMiGo1/1LiN3QQO0fuUqmEIb5Wj5po3eXch6FV3Vdq5RoekCuVfIUfD32CseEMC8qbj6R/Q==
+  dependencies:
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/reference" "^0.41.0"
+    "@glimmer/runtime" "^0.41.0"
+    "@glimmer/tracking" "^0.14.0-alpha.13"
+    "@glimmer/util" "^0.41.0"
+    broccoli-file-creator "^2.1.1"
+    broccoli-merge-trees "^3.0.2"
+    ember-cli-babel "^7.7.3"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "^2.0.0-rc.1"
+    ember-compatibility-helpers "^1.1.2"
+
+"@glimmer/di@^0.1.9":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
+  integrity sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=
+
 "@glimmer/di@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.1.tgz#5286b6b32040232b751138f6d006130c728d4b3d"
   integrity sha512-0D53YVuEgGdHfTl9LGWDZqVzGhn4cT0CXqyAuOYkKFLvqboJXz6SnkRhQNPhhA2hLVrPnvUz3+choQmPhHLGGQ==
+
+"@glimmer/encoder@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.41.4.tgz#4ccd292671e3f74d091cf28ff2c43bb9a080eb83"
+  integrity sha512-PNYi8vvyyyGuoZaWRuKc2L5nsuWdjAwo/TnwjfgVcgHh8/lBcPDYro3bPYd/E2Ddmj9QX3M8/UKw/dg3l5VuTw==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/vm" "^0.41.4"
 
 "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
+"@glimmer/interfaces@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"
+  integrity sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==
+
 "@glimmer/interfaces@^0.42.0":
   version "0.42.0"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.0.tgz#525f5352dd78011eef7b3eb0e3fb61b981c94319"
   integrity sha512-lZlydeRRK3yL6pco0gCstPVuC5XYjBUtql1vSvWTRd+MUO0Chg8kxIvduFVg6f+Xfr1kqWd2YQq1MCMdmfzfvg==
+
+"@glimmer/low-level@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.41.4.tgz#2b48574afb56b8b85578931f25c3880fb6381134"
+  integrity sha512-AvkGDIe2rHPRWeOp17/sMI1RSdBZW7NgzTSl/kPzOweWWuOOYTmzKGn641UeexVUeMMVf4AiMp/jPlXEqZ/pdw==
+
+"@glimmer/program@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.41.4.tgz#4903dce34900df75d3610e85b3e7eb6f8cdbacd9"
+  integrity sha512-q7mce9c/cKWEjFuPbB6LP2IuE3NC8eRtn0VKEt9QiGYqWa16cI+R7+ANb7tE+cjdgTIbEneTNY2X+Zx1DZpd0g==
+  dependencies:
+    "@glimmer/encoder" "^0.41.4"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+
+"@glimmer/reference@^0.41.0", "@glimmer/reference@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.41.4.tgz#41bd25183b644138db54ed00379be5e6903e8919"
+  integrity sha512-v8KQdD9RSDoZXCTgyvH8AbEWOMy5W1UUuGr3t6YZC7cecFAjarCeDEvbU+k9EGopTXisf9BVeUgtHj6cTMtiAw==
+  dependencies:
+    "@glimmer/util" "^0.41.4"
 
 "@glimmer/resolver@^0.4.1":
   version "0.4.3"
@@ -1084,6 +1145,19 @@
   integrity sha512-UhX6vlZbWRMq6pCquSC3wfWLM9kO0PhQPD1dZ3XnyZkmsvEE94Cq+EncA9JalUuevKoJrfUFRvrZ0xaz+yar3g==
   dependencies:
     "@glimmer/di" "^0.2.0"
+
+"@glimmer/runtime@^0.41.0":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.41.4.tgz#054d05132c40d5dbf2934580b2ab3a62bf32bdb9"
+  integrity sha512-tFiGsZ0ysy6MSIaTIyBnOEJbe3PHik510WqIRN/4Rne32S9k7HzH5tFHTJMkvAV6vmPoGAqK7EDHmwJy5l7/2A==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/low-level" "^0.41.4"
+    "@glimmer/program" "^0.41.4"
+    "@glimmer/reference" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+    "@glimmer/vm" "^0.41.4"
+    "@glimmer/wire-format" "^0.41.4"
 
 "@glimmer/syntax@^0.42.0":
   version "0.42.0"
@@ -1095,10 +1169,42 @@
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
+"@glimmer/tracking@^0.14.0-alpha.13":
+  version "0.14.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-0.14.0-alpha.13.tgz#aac853f3bd1ce2e076b9dec3495e5af84e9156de"
+  integrity sha512-JI6sI/v6c7mjWu4k9++/LVakEyvOxcUqpbJ7W4KwgpcYHtv8giVzQkR3gECJZp+PKRnhnU5OVyG+KsN1ZV2ptQ==
+  dependencies:
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/reference" "^0.41.0"
+    "@glimmer/runtime" "^0.41.0"
+    "@glimmer/util" "^0.41.0"
+
+"@glimmer/util@^0.41.0", "@glimmer/util@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.4.tgz#508fd82ca40305416e130f0da7b537295ded7989"
+  integrity sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==
+
 "@glimmer/util@^0.42.0":
   version "0.42.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.0.tgz#3f3a647ecaa16bbe4fc0545923d3b0a527319d78"
   integrity sha512-rvXxKVb7BoQUvdrEQgxyvIeqGRUFM4LZAc7X1OmIpMnoaEh3fyx/e8Bz0blF0Yk6QvHpfV/GKirhlGmfum/ISA==
+
+"@glimmer/vm@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.41.4.tgz#e6420c03dcaf97cc7cdb5a68bb098ed3ca51319c"
+  integrity sha512-rWFSyosGNi5ph84DKuT1B9u0fvonRZJ3oIk7tLvfAgAVVT87YFl8731kvu87qIB9bMPG8mgcVt4N8jf2r5ibYg==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+
+"@glimmer/wire-format@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.41.4.tgz#edc3279b8216363c925e771b2e2cbe408f2a0812"
+  integrity sha512-vp3Z+PjYkgCCyj5HX3cFB6Mag76GwVkI0cx9vMHKDoqJFJBicxc9JPymNuPuEithsJpUXJj2g7TKwJaliH2+cw==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
 
 "@glimmer/wire-format@^0.42.0":
   version "0.42.0"
@@ -5618,7 +5724,7 @@ ember-cli-test-loader@^2.2.0:
   dependencies:
     ember-cli-babel "^6.8.1"
 
-ember-cli-typescript@^2.0.0, ember-cli-typescript@^2.0.2:
+ember-cli-typescript@^2.0.0, ember-cli-typescript@^2.0.0-rc.1, ember-cli-typescript@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-2.0.2.tgz#464984131fbdc05655eb61d1c3cdd911d3137f0d"
   integrity sha512-7I5azCTxOgRDN8aSSnJZIKSqr+MGnT+jLTUbBYqF8wu6ojs2DUnTePxUcQMcvNh3Q3B1ySv7Q/uZFSjdU9gSjA==
@@ -5765,7 +5871,7 @@ ember-cli@~3.13.0:
     watch-detector "^1.0.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0:
+ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==


### PR DESCRIPTION
This PR updates the code to use some of the Ember Octane edition idioms. Specifically, it takes advantage of render modifiers and converts all the components to the `@glimmer/component` base class.